### PR TITLE
chore: bump canbench version to 0.2.0

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Run Tests
         shell: bash
         run: |
-          cargo test --release --all-targets --workspace --exclude benchmarks --color always -- --color always
+          cargo test --release --all-targets --workspace --exclude benchmarks -- --color always
         env:
           RUST_BACKTRACE: 1
 
@@ -477,6 +477,11 @@ jobs:
         with:
           name: canbench_result_${{github.job}}
           path: /tmp/canbench_result_${{ github.job }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: canbench_results_${{ matrix.name }}_csv
+          path: /tmp/canbench_results_${{ matrix.name }}.csv
 
       - name: Save PR number
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ version = "0.1.0"
 dependencies = [
  "bitcoin",
  "canbench-rs",
- "candid 0.10.10",
+ "candid 0.10.14",
  "hex",
  "ic-cdk 0.15.1",
  "ic-cdk-macros 0.15.0",
@@ -610,21 +610,21 @@ dependencies = [
 
 [[package]]
 name = "canbench-rs"
-version = "0.1.11"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a43b28f9982ece540df60672d7aff1ba5ba72640ea973b7e2f03cd34cc432cde"
+checksum = "1bf8bb62243691def9834aeab86a137177fed7e46ec802456488dd671f0979bd"
 dependencies = [
  "canbench-rs-macros",
- "candid 0.10.10",
- "ic-cdk 0.12.2",
+ "candid 0.10.14",
+ "ic-cdk 0.17.2",
  "serde",
 ]
 
 [[package]]
 name = "canbench-rs-macros"
-version = "0.1.11"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39f683bcc2d01b198dc12f38e59832053d372c910e6e6ac94c9dfc66a558d95"
+checksum = "9fbe69748d1d4ab1c0588996318a6399087462dabccb9b913de615645c2a88c5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -662,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.10"
+version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c30ee7f886f296b6422c0ff017e89dd4f831521dfdcc76f3f71aae1ce817222"
+checksum = "f9d90f5a1426d0489283a0bd5da9ed406fb3e69597e0d823dcb88a1965bb58d2"
 dependencies = [
  "anyhow",
  "binread",
@@ -714,7 +714,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48a3da76f989cd350b7342c64c6c6008341bb6186f6832ef04e56dc50ba0fd76"
 dependencies = [
  "anyhow",
- "candid 0.10.10",
+ "candid 0.10.14",
  "codespan-reporting",
  "convert_case",
  "hex",
@@ -730,7 +730,7 @@ dependencies = [
 name = "canister_backend"
 version = "0.1.0"
 dependencies = [
- "candid 0.10.10",
+ "candid 0.10.14",
  "futures",
  "ic-cdk 0.15.1",
  "ic-cdk-macros 0.15.0",
@@ -1100,7 +1100,7 @@ name = "disable-api-if-not-fully-synced-flag"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid 0.10.10",
+ "candid 0.10.14",
  "ic-cdk 0.15.1",
  "ic-cdk-macros 0.15.0",
  "ic-doge-test-utils",
@@ -1716,7 +1716,7 @@ dependencies = [
  "async-lock 3.4.0",
  "backoff",
  "cached",
- "candid 0.10.10",
+ "candid 0.10.14",
  "ed25519-consensus",
  "futures-util",
  "hex",
@@ -1763,29 +1763,36 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.12.2"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e908da565d9e304e83732500069ebb959e3d2cad80f894889ea37207112c7a0"
+checksum = "038ff230bf0fc8630943e3c52e989d248a7c89834ccb65da408fabc5817a475b"
 dependencies = [
- "candid 0.10.10",
- "ic-cdk-macros 0.8.4",
- "ic0 0.21.1",
+ "candid 0.10.14",
+ "ic-cdk-macros 0.15.0",
+ "ic0 0.23.0",
  "serde",
  "serde_bytes",
 ]
 
 [[package]]
 name = "ic-cdk"
-version = "0.15.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038ff230bf0fc8630943e3c52e989d248a7c89834ccb65da408fabc5817a475b"
+checksum = "95a7344f41493cbf591f13ae9f90181076f808a83af799815c3074b19c693d2e"
 dependencies = [
- "candid 0.10.10",
- "ic-cdk-macros 0.15.0",
+ "candid 0.10.14",
+ "ic-cdk-executor",
+ "ic-cdk-macros 0.17.2",
  "ic0 0.23.0",
  "serde",
  "serde_bytes",
 ]
+
+[[package]]
+name = "ic-cdk-executor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "903057edd3d4ff4b3fe44a64eaee1ceb73f579ba29e3ded372b63d291d7c16c2"
 
 [[package]]
 name = "ic-cdk-macros"
@@ -1803,25 +1810,25 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a618e4020cea88e933d8d2f8c7f86d570ec06213506a80d4f2c520a9bba512"
-dependencies = [
- "candid 0.10.10",
- "proc-macro2",
- "quote",
- "serde",
- "serde_tokenstream 0.1.7",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ic-cdk-macros"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af44fb4ec3a4b18831c9d3303ca8fa2ace846c4022d50cb8df4122635d3782e"
 dependencies = [
- "candid 0.10.10",
+ "candid 0.10.14",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_tokenstream 0.2.2",
+ "syn 2.0.75",
+]
+
+[[package]]
+name = "ic-cdk-macros"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84cbaa50fa36d3e0616114becf81faa95a099e0d60948ed6978f30f1c77399fd"
+dependencies = [
+ "candid 0.10.14",
  "proc-macro2",
  "quote",
  "serde",
@@ -1864,7 +1871,7 @@ dependencies = [
  "bitcoin",
  "byteorder",
  "canbench-rs",
- "candid 0.10.10",
+ "candid 0.10.14",
  "candid_parser",
  "ciborium",
  "datasize",
@@ -1891,7 +1898,7 @@ dependencies = [
 name = "ic-doge-interface"
 version = "0.1.0"
 dependencies = [
- "candid 0.10.10",
+ "candid 0.10.14",
  "ciborium",
  "datasize",
  "proptest 1.5.0",
@@ -1912,7 +1919,7 @@ name = "ic-doge-types"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid 0.10.10",
+ "candid 0.10.14",
  "datasize",
  "hex",
  "ic-doge-interface",
@@ -1935,7 +1942,7 @@ dependencies = [
 name = "ic-http"
 version = "0.1.0"
 dependencies = [
- "candid 0.10.10",
+ "candid 0.10.14",
  "futures",
  "ic-cdk 0.15.1",
  "ic-cdk-macros 0.15.0",
@@ -1964,7 +1971,7 @@ version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce14c068bd053c0f5ab525326f3f358f265cdfcae279fbf6461fb529e9682acd"
 dependencies = [
- "candid 0.10.10",
+ "candid 0.10.14",
  "hex",
  "ic-certification",
  "leb128",
@@ -1981,7 +1988,7 @@ version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
 dependencies = [
- "candid 0.10.10",
+ "candid 0.10.14",
  "hex",
  "ic-certification",
  "leb128",
@@ -2009,12 +2016,6 @@ name = "ic0"
 version = "0.18.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "576c539151d4769fb4d1a0c25c4108dd18facd04c5695b02cf2d226ab4e43aa5"
-
-[[package]]
-name = "ic0"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54b5297861c651551676e8c43df805dad175cc33bc97dbd992edbbb85dcbcdf"
 
 [[package]]
 name = "ic0"
@@ -2673,7 +2674,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "124a2380ca6f557adf8b02517cbfd2f564113230e14cda6f6aadd3dfe156293c"
 dependencies = [
  "base64 0.13.1",
- "candid 0.10.10",
+ "candid 0.10.14",
  "hex",
  "ic-certification",
  "ic-transport-types 0.37.1",
@@ -3425,7 +3426,7 @@ name = "scenario-1"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid 0.10.10",
+ "candid 0.10.14",
  "ic-cdk 0.15.1",
  "ic-cdk-macros 0.15.0",
  "ic-doge-test-utils",
@@ -3437,7 +3438,7 @@ name = "scenario-2"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid 0.10.10",
+ "candid 0.10.14",
  "ic-cdk 0.15.1",
  "ic-cdk-macros 0.15.0",
  "ic-doge-test-utils",
@@ -3449,7 +3450,7 @@ name = "scenario-3"
 version = "0.1.0"
 dependencies = [
  "bitcoin",
- "candid 0.10.10",
+ "candid 0.10.14",
  "ic-cdk 0.15.1",
  "ic-cdk-macros 0.15.0",
  "ic-doge-test-utils",
@@ -4364,7 +4365,7 @@ name = "uploader"
 version = "0.1.0"
 dependencies = [
  "async-std",
- "candid 0.10.10",
+ "candid 0.10.14",
  "clap",
  "hex",
  "ic-agent",
@@ -4542,7 +4543,7 @@ version = "0.1.0"
 dependencies = [
  "assert-json-diff",
  "async-trait",
- "candid 0.10.10",
+ "candid 0.10.14",
  "candid_parser",
  "futures",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,9 @@ members = [
     "types",
     "validation",
     "watchdog",
-
     # Crates for bootstrapping the state
     "bootstrap/state-builder",
     "bootstrap/uploader",
-
     # Crates used for testing only.
     "benchmarks",
     "e2e-tests/scenario-1",
@@ -29,7 +27,7 @@ resolver = "2"
 assert_matches = "1.5.0"
 bitcoin = "0.32.5"
 byteorder = "1.4.3"
-canbench-rs = "0.1.11"
+canbench-rs = "0.2.0"
 candid = "0.10.6"
 candid_parser = "0.1.4"
 ciborium = "0.2.1"

--- a/scripts/build-canister.sh
+++ b/scripts/build-canister.sh
@@ -23,10 +23,10 @@ fi
 # that aren't needed in production.
 if [[ -z "$FEATURES" ]]; then
   # No features provided
-  cargo build -p "$CANISTER" --target "$TARGET" --profile="${PROFILE}"
+  cargo build -p "$CANISTER" --target "$TARGET" --profile="${PROFILE}" --locked
 else
   # Features provided
-  cargo build -p "$CANISTER" --target "$TARGET" --profile="${PROFILE}" --features "$FEATURES"
+  cargo build -p "$CANISTER" --target "$TARGET" --profile="${PROFILE}" --locked --features "$FEATURES"
 fi
 
 # Navigate to root directory.

--- a/scripts/canbench_ci_run_benchmark.sh
+++ b/scripts/canbench_ci_run_benchmark.sh
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 set -Eexuo pipefail
 
-# Script that runs `canbench` at a given directory and outputs a comment
-# that is intended to be posted on the pull request.
+# This script runs `canbench` in a given directory and outputs a comment
+# intended to be posted on the pull request.
 
 # Path to run `canbench` from.
 CANISTER_PATH=$1
 
-# The name of the job in CI
+# The name of the CI job.
 CANBENCH_JOB_NAME=$2
 
-# Must match the file specified in the github action.
+# Must match the file path specified in the GitHub Action.
 COMMENT_MESSAGE_PATH=/tmp/canbench_result_${CANBENCH_JOB_NAME}
 
-# Github CI is expected to have the main branch checked out in this folder.
+# GitHub CI is expected to have the main branch checked out in this folder.
 MAIN_BRANCH_DIR=_canbench_main_branch
 
 CANBENCH_OUTPUT=/tmp/canbench_output.txt
@@ -21,28 +21,52 @@ CANBENCH_OUTPUT=/tmp/canbench_output.txt
 CANBENCH_RESULTS_FILE="$CANISTER_PATH/canbench_results.yml"
 MAIN_BRANCH_RESULTS_FILE="$MAIN_BRANCH_DIR/$CANBENCH_RESULTS_FILE"
 
-# Install canbench
-cargo install canbench --version 0.1.11
+CANBENCH_RESULTS_CSV_FILE="/tmp/canbench_results_${CANBENCH_JOB_NAME}.csv"
 
-# Verify that canbench results are available.
+# Install canbench.
+cargo install --version 0.2.0 --locked canbench
+
+# Verify that the canbench results file exists.
 if [ ! -f "$CANBENCH_RESULTS_FILE" ]; then
-    echo "$CANBENCH_RESULTS_FILE not found. Did you forget to run \`canbench --persist\`?";
+    echo "$CANBENCH_RESULTS_FILE not found. Did you forget to run \`canbench --persist [--csv]\`?"
     exit 1
 fi
 
-# Detect if canbench results file is up to date.
-pushd "$CANISTER_PATH"
-canbench --less-verbose > $CANBENCH_OUTPUT
-if grep -q "(regress\|(improved by \|(new)" "$CANBENCH_OUTPUT"; then
-  UPDATED_MSG="**❌ \`$CANBENCH_RESULTS_FILE\` is not up to date**
-  If the performance change is expected, run \`canbench --persist\` to save the updated benchmark results.";
+# Function that checks if the benchmark output contains any updates
+has_updates() {
+  # Triggers for streamed results (old format)
+  local streamed_patterns=(
+    "\(regressed by"
+    "\(improved by"
+    "\(new\)"
+  )
 
-  # canbench results file not up to date. Fail the job.
+  # Triggers for summary status (new format)
+  local summary_patterns=(
+    "status:[[:space:]]+Regressions"
+    "status:[[:space:]]+Improvements"
+    "status:[[:space:]]+New[[:space:]]+benchmarks"
+  )
+
+  # Combine all patterns into a single extended regex
+  local all_patterns
+  all_patterns=$(IFS='|'; echo "${streamed_patterns[*]}|${summary_patterns[*]}")
+
+  grep -qE "$all_patterns" "$CANBENCH_OUTPUT"
+}
+
+# Check if the canbench results file is up to date.
+pushd "$CANISTER_PATH"
+canbench --less-verbose --hide-results --show-summary --csv > "$CANBENCH_OUTPUT"
+cp "./canbench_results.csv" "$CANBENCH_RESULTS_CSV_FILE"
+if has_updates; then
+  UPDATED_MSG="**❌ \`$CANBENCH_RESULTS_FILE\` is not up to date**
+  If the performance change is expected, run \`canbench --persist [--csv]\` to update the benchmark results."
+  # Results are outdated; fail the job.
   echo "EXIT_STATUS=1" >> "$GITHUB_ENV"
 else
-  UPDATED_MSG="**✅ \`$CANBENCH_RESULTS_FILE\` is up to date**";
-
-  # canbench results file is up to date. The job succeeds.
+  UPDATED_MSG="✅ \`$CANBENCH_RESULTS_FILE\` is up to date"
+  # Results are up to date; job succeeds.
   echo "EXIT_STATUS=0" >> "$GITHUB_ENV"
 fi
 popd
@@ -54,34 +78,24 @@ time=$(date -u +"%Y-%m-%d %H:%M:%S UTC")
 # Print output with correct formatting
 echo "# \`canbench\` 🏋 (dir: $CANISTER_PATH) $commit_hash $time" > "$COMMENT_MESSAGE_PATH"
 
-# Detect if there are performance changes relative to the main branch.
+# Check for performance changes relative to the main branch.
 if [ -f "$MAIN_BRANCH_RESULTS_FILE" ]; then
-  # Move the results of the main branch into the current branch.
+  # Replace the current results with the main branch results.
   mv "$MAIN_BRANCH_RESULTS_FILE" "$CANBENCH_RESULTS_FILE"
 
-  # Run canbench to compare results to the main branch.
+  # Run canbench to compare results with the main branch.
   pushd "$CANISTER_PATH"
-  canbench --less-verbose > "$CANBENCH_OUTPUT"
+  canbench --less-verbose --show-summary --csv > "$CANBENCH_OUTPUT"
+  cp "./canbench_results.csv" "$CANBENCH_RESULTS_CSV_FILE"
   popd
-
-  # Append markers to individual benchmark results
-  awk '
-  /\(improved / { print $0, "🟢"; next }
-  /\(regressed / { print $0, "🔴"; next }
-  /\(new\)/ { print $0, "🟡"; next }
-  { print }
-  ' "$CANBENCH_OUTPUT" > "${CANBENCH_OUTPUT}.tmp" && mv "${CANBENCH_OUTPUT}.tmp" "$CANBENCH_OUTPUT"
-
-  # Add a top-level summary of detected performance changes
-  MESSAGE=""
-  grep -q "(improved " "${CANBENCH_OUTPUT}" && MESSAGE+="**🟢 Performance improvements detected! 🎉**\n"
-  grep -q "(regressed " "${CANBENCH_OUTPUT}" && MESSAGE+="**🔴 Performance regressions detected! 😱**\n"
-  echo -e "${MESSAGE:-**ℹ️ No significant performance changes detected 👍**}" >> "$COMMENT_MESSAGE_PATH"
 fi
 
-## Add the output of canbench to the file.
+CSV_RESULTS_FILE_MSG="📦 \`canbench_results_$CANBENCH_JOB_NAME.csv\` available in [artifacts](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})"
+
+# Append the update status and benchmark output to the comment.
 {
   echo "$UPDATED_MSG"
+  echo "$CSV_RESULTS_FILE_MSG"
   echo ""
   echo "\`\`\`"
   cat "$CANBENCH_OUTPUT"


### PR DESCRIPTION
This PR bumps canbench version to v0.2.0.

Canbench

- updated version to v0.2.0
- added --locked to all canister builds
- updated canbench scripts

CI

- (cleanup) removed excessive color always

Closes #4 