### PR TITLE
chore: remove redundant cargo workspace

### DIFF
--- a/ic-http/example_canister/Cargo.toml
+++ b/ic-http/example_canister/Cargo.toml
@@ -1,4 +1,0 @@
-[workspace]
-members = [
-    "src/canister_backend",
-]


### PR DESCRIPTION
Remove workspace declaration at `ic-http/example_canister/`, because `src/canister_backend` is already included in top-level workspace.