### PR TITLE
feat: use nat instead of u64 in external interfaces

### DIFF
--- a/canister/candid.did
+++ b/canister/candid.did
@@ -4,7 +4,7 @@ type network = variant {
   regtest;
 };
 
-type satoshi = nat64;
+type satoshi = nat;
 
 type address = text;
 
@@ -102,7 +102,7 @@ type send_transaction_request = record {
   transaction : blob;
 };
 
-type millisatoshi_per_byte = nat64;
+type millisatoshi_per_byte = nat;
 
 type set_config_request = record {
   stability_threshold : opt nat;

--- a/canister/src/address_utxoset.rs
+++ b/canister/src/address_utxoset.rs
@@ -67,7 +67,7 @@ impl<'a> AddressUtxoSet<'a> {
                 });
             self.added_utxos.insert(Utxo {
                 outpoint: outpoint.clone(),
-                value: txout.value,
+                value: txout.value.into(),
                 height,
             });
         }
@@ -96,7 +96,7 @@ impl<'a> AddressUtxoSet<'a> {
                 Utxo {
                     outpoint,
                     height,
-                    value: tx_out.value,
+                    value: tx_out.value.into(),
                 }
             });
 
@@ -121,7 +121,7 @@ mod test {
         types::into_dogecoin_network,
         unstable_blocks,
     };
-    use ic_doge_interface::Network;
+    use ic_doge_interface::{Network, Satoshi};
     use ic_doge_test_utils::random_p2pkh_address;
     use ic_doge_types::OutPoint;
 
@@ -157,7 +157,7 @@ mod test {
                     txid: coinbase_tx.txid(),
                     vout: 0
                 },
-                value: 1000,
+                value: Satoshi::from(1000u32),
                 height: 0
             }]
         );
@@ -210,7 +210,7 @@ mod test {
                     txid: tx.txid(),
                     vout: 0
                 },
-                value: 1000,
+                value: Satoshi::from(1000u32),
                 height: 1
             }]
         );
@@ -268,7 +268,7 @@ mod test {
                     txid: tx.txid(),
                     vout: 1
                 },
-                value: 400,
+                value: Satoshi::from(400u32),
                 height: 1
             }]
         );
@@ -281,7 +281,7 @@ mod test {
                     txid: tx.txid(),
                     vout: 0
                 },
-                value: 1500,
+                value: Satoshi::from(1500u32),
                 height: 1
             }]
         );

--- a/canister/src/api/get_balance.rs
+++ b/canister/src/api/get_balance.rs
@@ -181,7 +181,7 @@ mod test {
                     address: address.to_string(),
                     min_confirmations: *min_confirmations
                 }),
-                Ok(1000)
+                Ok(Satoshi::from(1000u32))
             );
         }
 
@@ -192,7 +192,7 @@ mod test {
                 min_confirmations: Some(2)
             })
             .unwrap(),
-            0
+            Satoshi::from(0u32)
         );
     }
 
@@ -215,7 +215,7 @@ mod test {
                     min_confirmations
                 })
                 .unwrap(),
-                0
+                Satoshi::from(0u32)
             );
         }
 
@@ -278,7 +278,7 @@ mod test {
                     min_confirmations: *min_confirmations
                 })
                 .unwrap(),
-                1000
+                Satoshi::from(1000u32)
             );
 
             assert_eq!(
@@ -287,7 +287,7 @@ mod test {
                     min_confirmations: *min_confirmations
                 })
                 .unwrap(),
-                0
+                Satoshi::from(0u32)
             );
         }
 
@@ -299,7 +299,7 @@ mod test {
                 min_confirmations: Some(2)
             })
             .unwrap(),
-            0
+            Satoshi::from(0u32)
         );
         assert_eq!(
             get_balance(GetBalanceRequest {
@@ -307,7 +307,7 @@ mod test {
                 min_confirmations: Some(2)
             })
             .unwrap(),
-            1000
+            Satoshi::from(1000u32)
         );
     }
 

--- a/canister/src/api/get_utxos.rs
+++ b/canister/src/api/get_utxos.rs
@@ -5,7 +5,9 @@ use crate::{
     types::{Address, GetUtxosRequest, Page, Utxo},
     unstable_blocks, verify_has_enough_cycles, with_state, with_state_mut, State,
 };
-use ic_doge_interface::{GetUtxosError, GetUtxosResponse, Utxo as PublicUtxo, UtxosFilter};
+use ic_doge_interface::{
+    GetUtxosError, GetUtxosResponse, Satoshi, Utxo as PublicUtxo, UtxosFilter,
+};
 use ic_doge_types::{Block, BlockHash, OutPoint, Txid};
 use serde_bytes::ByteBuf;
 use std::str::FromStr;
@@ -149,7 +151,7 @@ fn get_utxos_internal(
                 Some(Utxo {
                     height,
                     outpoint,
-                    value: 0,
+                    value: Satoshi::from(0u32),
                 }),
                 utxo_limit,
             )
@@ -391,7 +393,7 @@ mod test {
                         txid: coinbase_tx.txid().into(),
                         vout: 0
                     },
-                    value: 1000,
+                    value: Satoshi::from(1000u32),
                     height: 1,
                 }],
                 tip_block_hash: block.block_hash().to_vec(),
@@ -459,7 +461,7 @@ mod test {
                     txid: transactions[i as usize].txid().into(),
                     vout: 0,
                 },
-                value: i + 1,
+                value: Satoshi::from(i + 1),
                 height: (i + 1) as u32,
             };
             if i % 2 == 0 {
@@ -551,7 +553,7 @@ mod test {
                             txid: tx.txid().into(),
                             vout: 0,
                         },
-                        value: 1000,
+                        value: Satoshi::from(1000u32),
                         height: 2,
                     }],
                     tip_block_hash: block_1.block_hash().to_vec(),
@@ -602,7 +604,7 @@ mod test {
                         txid: coinbase_tx.txid().into(),
                         vout: 0,
                     },
-                    value: 1000,
+                    value: Satoshi::from(1000u32),
                     height: 1,
                 }],
                 tip_block_hash: block_0.block_hash().to_vec(),
@@ -688,7 +690,7 @@ mod test {
                     txid: coinbase_tx.txid().into(),
                     vout: 0,
                 },
-                value: 1000,
+                value: Satoshi::from(1000u32),
                 height: 1,
             }],
             tip_block_hash: block_0.block_hash().to_vec(),
@@ -732,7 +734,7 @@ mod test {
                         txid: tx.txid().into(),
                         vout: 0,
                     },
-                    value: 1000,
+                    value: Satoshi::from(1000u32),
                     height: 2,
                 }],
                 tip_block_hash: block_1.block_hash().to_vec(),
@@ -873,7 +875,7 @@ mod test {
                         txid: tx.txid().into(),
                         vout: 0,
                     },
-                    value: 1000,
+                    value: Satoshi::from(1000u32),
                     height: 3,
                 }],
                 tip_block_hash: block_2_prime.block_hash().to_vec(),
@@ -921,7 +923,7 @@ mod test {
                         txid: tx.txid().into(),
                         vout: 0
                     },
-                    value: 1000,
+                    value: Satoshi::from(1000u32),
                     height: 1,
                 }],
                 tip_block_hash: block_0.block_hash().to_vec(),

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -338,7 +338,7 @@ mod test {
         utxo_set::IngestingBlock,
     };
     use bitcoin::block::Header;
-    use ic_doge_interface::{InitConfig, Network};
+    use ic_doge_interface::{InitConfig, Network, Satoshi};
     use ic_doge_test_utils::random_p2pkh_address;
 
     fn build_block(prev_header: &Header, address: Address, num_transactions: u128) -> Block {
@@ -634,7 +634,7 @@ mod test {
                     min_confirmations: None
                 })
                 .unwrap(),
-                0
+                Satoshi::from(0u32)
             );
 
             assert_eq!(
@@ -665,7 +665,7 @@ mod test {
                 min_confirmations: None
             })
             .unwrap(),
-            0
+            Satoshi::from(0u32)
         );
 
         assert_eq!(
@@ -732,7 +732,7 @@ mod test {
                 min_confirmations: None
             })
             .unwrap(),
-            0
+            Satoshi::from(0u32)
         );
 
         // Process response.
@@ -745,7 +745,7 @@ mod test {
                 min_confirmations: None
             })
             .unwrap(),
-            1000
+            Satoshi::from(1000u32)
         );
     }
 

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -4,8 +4,10 @@ use ic_doge_canister::types::{HttpRequest, HttpResponse};
 use ic_doge_interface::{
     Config, GetBalanceRequest, GetBlockHeadersRequest, GetBlockHeadersResponse,
     GetCurrentFeePercentilesRequest, GetUtxosRequest, GetUtxosResponse, InitConfig,
-    MillisatoshiPerByte, Satoshi, SendTransactionRequest, SetConfigRequest,
+    MillisatoshiPerByte, SendTransactionRequest, SetConfigRequest,
 };
+
+type Satoshi = candid::Nat;
 
 #[cfg(target_arch = "wasm32")]
 mod printer;

--- a/canister/src/tests.rs
+++ b/canister/src/tests.rs
@@ -21,7 +21,7 @@ use bitcoin::{
 use byteorder::{LittleEndian, ReadBytesExt};
 use ic_cdk::api::call::RejectionCode;
 use ic_doge_interface::{Flag, GetUtxosResponse, InitConfig, Network, Txid, UtxosFilter};
-use ic_doge_interface::{OutPoint, Utxo};
+use ic_doge_interface::{OutPoint, Satoshi, Utxo};
 use ic_doge_test_utils::random_p2pkh_address;
 use ic_doge_types::{Block, BlockHash};
 use std::str::FromStr;
@@ -176,7 +176,7 @@ async fn mainnet_14k_blocks() {
             min_confirmations: None
         })
         .unwrap(),
-        0
+        Satoshi::from(0u64)
     );
 
     assert_eq!(
@@ -194,7 +194,7 @@ async fn mainnet_14k_blocks() {
                     .unwrap(),
                     vout: 0,
                 },
-                value: 5862238267983,
+                value: Satoshi::from(5862238267983u64),
                 height: 14_000,
             }],
             // The tip should be the block hash at height 14,000
@@ -216,7 +216,7 @@ async fn mainnet_14k_blocks() {
             min_confirmations: None
         })
         .unwrap(),
-        45336054896700
+        Satoshi::from(45336054896700u64)
     );
 
     assert_eq!(
@@ -234,7 +234,7 @@ async fn mainnet_14k_blocks() {
                     .unwrap(),
                     vout: 0,
                 },
-                value: 8_690_929_966_050,
+                value: Satoshi::from(8_690_929_966_050u64),
                 height: 14_000,
             }],
             // The tip should be the block hash at height 14,000
@@ -257,7 +257,7 @@ async fn mainnet_14k_blocks() {
             min_confirmations: None
         })
         .unwrap(),
-        0
+        Satoshi::from(0u64)
     );
 
     // At 7 confirmations it should have its DOGE.
@@ -267,7 +267,7 @@ async fn mainnet_14k_blocks() {
             min_confirmations: Some(7)
         })
         .unwrap(),
-        9_765_874_508_790
+        Satoshi::from(9_765_874_508_790u64)
     );
 
     // At 6 confirmations it should have its DOGE.
@@ -277,7 +277,7 @@ async fn mainnet_14k_blocks() {
             min_confirmations: Some(6)
         })
         .unwrap(),
-        9_765_874_508_790
+        Satoshi::from(9_765_874_508_790u64)
     );
 
     assert_eq!(
@@ -295,7 +295,7 @@ async fn mainnet_14k_blocks() {
                     .unwrap(),
                     vout: 0,
                 },
-                value: 9_765_874_508_790,
+                value: Satoshi::from(9_765_874_508_790u64),
                 height: 13_994,
             }],
             // The tip should be the block hash at height 13,994
@@ -317,7 +317,7 @@ async fn mainnet_14k_blocks() {
             min_confirmations: Some(5)
         })
         .unwrap(),
-        0
+        Satoshi::from(0u64)
     );
 
     // The DOGE is spent to the following two addresses.
@@ -327,7 +327,7 @@ async fn mainnet_14k_blocks() {
             min_confirmations: Some(5),
         })
         .unwrap(),
-        9_548_597_846_038
+        Satoshi::from(9_548_597_846_038u64)
     );
 
     assert_eq!(
@@ -336,7 +336,7 @@ async fn mainnet_14k_blocks() {
             min_confirmations: Some(5)
         })
         .unwrap(),
-        242_276_662_752
+        Satoshi::from(242_276_662_752u64)
     );
 
     // The first address should have a balance of zero before that height.
@@ -346,7 +346,7 @@ async fn mainnet_14k_blocks() {
             min_confirmations: Some(6),
         })
         .unwrap(),
-        0
+        Satoshi::from(0u64)
     );
 
     // The second address should have a balance of 250 DOGE before that height.
@@ -356,7 +356,7 @@ async fn mainnet_14k_blocks() {
             min_confirmations: Some(6),
         })
         .unwrap(),
-        25_000_000_000
+        Satoshi::from(25_000_000_000u64)
     );
 
     // Check the block headers/heights of a few random blocks.
@@ -534,7 +534,7 @@ async fn time_slices_large_block_with_multiple_transactions() {
             min_confirmations: None
         })
         .unwrap(),
-        2000
+        Satoshi::from(2000u64)
     );
 
     assert_eq!(
@@ -543,7 +543,7 @@ async fn time_slices_large_block_with_multiple_transactions() {
             min_confirmations: None
         })
         .unwrap(),
-        2000
+        Satoshi::from(2000u64)
     );
 }
 

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -581,7 +581,7 @@ fn test_utxo_ordering() {
             txid: Txid::from(vec![]),
             vout: 0,
         },
-        value: 123,
+        value: Satoshi::from(123u32),
     };
 
     let b = Utxo {
@@ -590,7 +590,7 @@ fn test_utxo_ordering() {
             txid: Txid::from(vec![1]),
             vout: 0,
         },
-        value: 123,
+        value: Satoshi::from(123u32),
     };
 
     let c = Utxo {
@@ -599,7 +599,7 @@ fn test_utxo_ordering() {
             txid: Txid::from(vec![1]),
             vout: 0,
         },
-        value: 123,
+        value: Satoshi::from(123u32),
     };
 
     let d = Utxo {
@@ -608,7 +608,7 @@ fn test_utxo_ordering() {
             txid: Txid::from(vec![1]),
             vout: 0,
         },
-        value: 124,
+        value: Satoshi::from(124u32),
     };
 
     // a < b == c < d

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -175,7 +175,7 @@ impl UtxoSet {
             }
         }
 
-        balance
+        Satoshi::from(balance)
     }
 
     /// Returns the UTXO of the given outpoint.
@@ -438,7 +438,7 @@ impl UtxoSet {
 
     #[cfg(test)]
     pub fn get_total_supply(&self) -> Satoshi {
-        self.utxos.iter().map(|(_, (v, _))| v.value).sum()
+        Satoshi::from(self.utxos.iter().map(|(_, (v, _))| v.value).sum::<u64>())
     }
 }
 
@@ -686,7 +686,7 @@ mod test {
                 txid: coinbase_tx.txid(),
                 vout: 0,
             },
-            value: 1000,
+            value: Satoshi::from(1000u32),
             height: 0,
         }];
 
@@ -734,7 +734,7 @@ mod test {
                     txid: tx.txid(),
                     vout: 0
                 },
-                value: 1000,
+                value: Satoshi::from(1000u32),
                 height: 1
             }]
         );
@@ -900,8 +900,8 @@ mod test {
                 }
             ))
         );
-        assert_eq!(utxo_set.get_balance(&address_1), 0);
-        assert_eq!(utxo_set.get_balance(&address_2), 1_000);
+        assert_eq!(utxo_set.get_balance(&address_1), Satoshi::from(0u32));
+        assert_eq!(utxo_set.get_balance(&address_2), Satoshi::from(1_000u32));
     }
 
     #[test]
@@ -1047,8 +1047,8 @@ mod test {
                     // what we expect if only block 0 is ingested.
 
                     assert_eq!(utxo_set.get_balance(&address_1), tx_cardinality);
-                    assert_eq!(utxo_set.get_balance(&address_2), 0);
-                    assert_eq!(utxo_set.get_balance(&address_3), 0);
+                    assert_eq!(utxo_set.get_balance(&address_2), Satoshi::from(0u32));
+                    assert_eq!(utxo_set.get_balance(&address_3), Satoshi::from(0u32));
 
                     assert_eq!(
                         utxo_set
@@ -1109,8 +1109,8 @@ mod test {
 
             // Finished ingesting block 1. Assert that the balances, addresses outpoints, and
             // UTXOs are updated accordingly.
-            assert_eq!(utxo_set.get_balance(&address_1), 0);
-            assert_eq!(utxo_set.get_balance(&address_2), 0);
+            assert_eq!(utxo_set.get_balance(&address_1), Satoshi::from(0u32));
+            assert_eq!(utxo_set.get_balance(&address_2), Satoshi::from(0u32));
             assert_eq!(utxo_set.get_balance(&address_3), tx_cardinality);
             assert_eq!(
                 num_rounds,

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -1,6 +1,6 @@
 //! Types used in the interface of the Dogecoin Canister.
 
-use candid::{CandidType, Deserialize, Principal};
+use candid::{CandidType, Deserialize, Nat, Principal};
 use datasize::DataSize;
 use serde::Serialize;
 use serde_bytes::ByteBuf;
@@ -8,8 +8,8 @@ use std::fmt;
 use std::str::FromStr;
 
 pub type Address = String;
-pub type Satoshi = u64;
-pub type MillisatoshiPerByte = u64;
+pub type Satoshi = Nat;
+pub type MillisatoshiPerByte = Nat;
 pub type BlockHash = Vec<u8>;
 pub type Height = u32;
 pub type Page = ByteBuf;


### PR DESCRIPTION
XC-492: DOGE canister: user balance and UTXO value may overflow a `u64` in 5 years

A first step towards a fix is to replace u64 with the Nat type from candid in external interfaces.