### PR TITLE
feat: change satoshi to koinu and use nat for get_balance calls

### DIFF
--- a/INTERFACE_SPECIFICATION.md
+++ b/INTERFACE_SPECIFICATION.md
@@ -18,7 +18,9 @@ type network = variant {
   regtest;
 };
 
-type satoshi = nat64;
+type amount = nat;
+
+type koinu = nat64;
 
 type address = text;
 
@@ -33,7 +35,7 @@ type outpoint = record {
 
 type utxo = record {
   outpoint : outpoint;
-  value : satoshi;
+  value : koinu;
   height : block_height;
 };
 
@@ -91,7 +93,7 @@ The recommended workflow is to issue a request with the desired number of confir
 ### `dogecoin_get_utxos_query`
 
 ```
-dogecoin_get_balance_query : (get_balance_request) -> (satoshi) query;
+dogecoin_get_balance_query : (get_balance_request) -> (amount) query;
 ```
 
 
@@ -107,12 +109,12 @@ type get_balance_request = record {
   min_confirmations : opt nat32;
 };
 
-dogecoin_get_balance : (get_balance_request) -> (satoshi);
+dogecoin_get_balance : (get_balance_request) -> (amount);
 ```
 
 This endpoint can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
-Given a `get_balance_request`, which must specify a Dogecoin address and a Dogecoin network (`mainnet` or `testnet`), the function returns the current balance of this address in `Satoshi` (10^8 Satoshi = 1 Dogecoin) in the specified Dogecoin network. The same address formats as for `dogecoin_get_utxos` are supported.
+Given a `get_balance_request`, which must specify a Dogecoin address and a Dogecoin network (`mainnet` or `testnet`), the function returns the current balance of this address in `Koinu` (10^8 Koinu = 1 Dogecoin) in the specified Dogecoin network. The same address formats as for `dogecoin_get_utxos` are supported.
 
 If the address is malformed, the call is rejected.
 
@@ -123,7 +125,7 @@ Given an address and the optional `min_confirmations` parameter, `dogecoin_get_b
 ### `dogecoin_get_balance_query`
 
 ```
-dogecoin_get_balance_query : (get_balance_request) -> (satoshi) query;
+dogecoin_get_balance_query : (get_balance_request) -> (amount) query;
 ```
 
 This endpoint is identical to `dogecoin_get_balance` but can _only_ be invoked in a query call.
@@ -136,16 +138,16 @@ type get_current_fee_percentiles_request = record {
   network : network;
 };
 
-type millisatoshi_per_byte = nat64;
+type millikoinu_per_byte = nat64;
 
-dogecoin_get_current_fee_percentiles : (get_current_fee_percentiles_request) -> (vec millisatoshi_per_byte);
+dogecoin_get_current_fee_percentiles : (get_current_fee_percentiles_request) -> (vec millikoinu_per_byte);
 ```
 
 This endpoint can only be called by canisters, i.e., it cannot be called by external users via ingress messages.
 
 The transaction fees in the Dogecoin network change dynamically based on the number of pending transactions. It must be possible for a canister to determine an adequate fee when creating a Dogecoin transaction.
 
-This function returns fee percentiles, measured in millisatoshi/vbyte (1000 millisatoshi = 1 satoshi), over the last 10,000 transactions in the specified network, i.e., over the transactions in the last approximately 4-10 blocks.
+This function returns fee percentiles, measured in millikoinu/vbyte (1000 millikoinu = 1 koinu), over the last 10,000 transactions in the specified network, i.e., over the transactions in the last approximately 4-10 blocks.
 
 The [standard nearest-rank estimation method](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method), inclusive, with the addition of a 0th percentile is used. Concretely, for any i from 1 to 100, the ith percentile is the fee with rank `⌈i * 100⌉`. The 0th percentile is defined as the smallest fee (excluding coinbase transactions).
 

--- a/INTERFACE_SPECIFICATION.md
+++ b/INTERFACE_SPECIFICATION.md
@@ -147,7 +147,7 @@ This endpoint can only be called by canisters, i.e., it cannot be called by exte
 
 The transaction fees in the Dogecoin network change dynamically based on the number of pending transactions. It must be possible for a canister to determine an adequate fee when creating a Dogecoin transaction.
 
-This function returns fee percentiles, measured in millikoinu/vbyte (1000 millikoinu = 1 koinu), over the last 10,000 transactions in the specified network, i.e., over the transactions in the last approximately 4-10 blocks.
+This function returns fee percentiles, measured in millikoinu/byte (1000 millikoinu = 1 koinu), over the last 10,000 transactions in the specified network, i.e., over the transactions in the last approximately 4-10 blocks.
 
 The [standard nearest-rank estimation method](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method), inclusive, with the addition of a 0th percentile is used. Concretely, for any i from 1 to 100, the ith percentile is the fee with rank `⌈i * 100⌉`. The 0th percentile is defined as the smallest fee (excluding coinbase transactions).
 

--- a/canister/candid.did
+++ b/canister/candid.did
@@ -4,7 +4,13 @@ type network = variant {
   regtest;
 };
 
-type satoshi = nat64;
+// Under current issurance rate, the total market cap of DOGE is going to exceed 
+// the bound if nat64 by around year 2030. So it is safer to use nat to represent
+// the amount of DOGE in koinus (the smallest unit of DOGE).
+type amount = nat;
+
+// Since Utxo value cannot exceed 10B DOGE, nat64 can be used.
+type koinu = nat64;
 
 type address = text;
 
@@ -21,7 +27,7 @@ type outpoint = record {
 
 type utxo = record {
   outpoint : outpoint;
-  value : satoshi;
+  value : utxo_koinu;
   height : block_height;
 };
 
@@ -102,7 +108,8 @@ type send_transaction_request = record {
   transaction : blob;
 };
 
-type millisatoshi_per_byte = nat64;
+// Transaction fee cannot exceed 10B DOGE, it is safe to use nat64 here.
+type millikoinu_per_byte = nat64;
 
 type set_config_request = record {
   stability_threshold : opt nat;
@@ -127,15 +134,15 @@ type get_block_headers_response = record {
 };
 
 service dogecoin : (init_config) -> {
-  dogecoin_get_balance : (get_balance_request) -> (satoshi);
+  dogecoin_get_balance : (get_balance_request) -> (amount);
 
-  dogecoin_get_balance_query : (get_balance_request) -> (satoshi) query;
+  dogecoin_get_balance_query : (get_balance_request) -> (amount) query;
 
   dogecoin_get_utxos : (get_utxos_request) -> (get_utxos_response);
 
   dogecoin_get_utxos_query : (get_utxos_request) -> (get_utxos_response) query;
 
-  dogecoin_get_current_fee_percentiles : (get_current_fee_percentiles_request) -> (vec millisatoshi_per_byte);
+  dogecoin_get_current_fee_percentiles : (get_current_fee_percentiles_request) -> (vec millikoinu_per_byte);
 
   dogecoin_get_block_headers : (get_block_headers_request) -> (get_block_headers_response);
 

--- a/canister/candid.did
+++ b/canister/candid.did
@@ -27,7 +27,7 @@ type outpoint = record {
 
 type utxo = record {
   outpoint : outpoint;
-  value : utxo_koinu;
+  value : koinu;
   height : block_height;
 };
 

--- a/canister/candid.did
+++ b/canister/candid.did
@@ -4,12 +4,12 @@ type network = variant {
   regtest;
 };
 
-// Under current issurance rate, the total market cap of DOGE is going to exceed 
-// the bound if nat64 by around year 2030. So it is safer to use nat to represent
-// the amount of DOGE in koinus (the smallest unit of DOGE).
+// The total amount of DOGE is going to exceed the bound of nat64 by around year 2030.
+// So it is safer to use nat to represent an arbitrary amount of DOGE in koinus.
 type amount = nat;
 
-// Since Utxo value cannot exceed 10B DOGE, nat64 can be used.
+// The smallest unit of DOGE: 10^8 koinu = 1 DOGE. The value of an UTXO can be safely
+// represented as a nat64 value because it cannot exceed 10B DOGE according to the protocol.
 type koinu = nat64;
 
 type address = text;
@@ -108,7 +108,7 @@ type send_transaction_request = record {
   transaction : blob;
 };
 
-// Transaction fee cannot exceed 10B DOGE, it is safe to use nat64 here.
+// Transaction fee cannot exceed 10B DOGE, which can be safely represented by nat64.
 type millikoinu_per_byte = nat64;
 
 type set_config_request = record {

--- a/canister/candid.did
+++ b/canister/candid.did
@@ -108,7 +108,8 @@ type send_transaction_request = record {
   transaction : blob;
 };
 
-// Transaction fee cannot exceed 10B DOGE, which can be safely represented by nat64.
+// DOGE transaction fee in millikoinu_per_byte is usually between 10^9 and 10^10.
+// It should be safe to assume this value can be represented by u64.
 type millikoinu_per_byte = nat64;
 
 type set_config_request = record {

--- a/canister/src/address_utxoset.rs
+++ b/canister/src/address_utxoset.rs
@@ -134,7 +134,7 @@ mod test {
 
         let utxo_set = UtxoSet::new(network);
 
-        // Create a genesis block where 1000 satoshis are given to address 1.
+        // Create a genesis block where 1000 koinus are given to address 1.
         let coinbase_tx = TransactionBuilder::coinbase()
             .with_output(&address_1, 1000)
             .build();
@@ -173,7 +173,7 @@ mod test {
 
         let utxo_set = UtxoSet::new(network);
 
-        // Create a genesis block where 1000 satoshis are given to address 1.
+        // Create a genesis block where 1000 koinus are given to address 1.
         let coinbase_tx = TransactionBuilder::coinbase()
             .with_output(&address_1, 1000)
             .build();
@@ -181,7 +181,7 @@ mod test {
             .with_transaction(coinbase_tx.clone())
             .build();
 
-        // Extend block 0 with block 1 that spends the 1000 satoshis and gives them to address 2.
+        // Extend block 0 with block 1 that spends the 1000 koinus and gives them to address 2.
         let tx = TransactionBuilder::new()
             .with_input(OutPoint::new(coinbase_tx.txid(), 0))
             .with_output(&address_2, 1000)
@@ -225,7 +225,7 @@ mod test {
         let address_1 = random_p2pkh_address(doge_network).into();
         let address_2 = random_p2pkh_address(doge_network).into();
 
-        // Create a genesis block where 2000 satoshis are given to address 1
+        // Create a genesis block where 2000 koinus are given to address 1
         // in two different outputs.
         let coinbase_tx = TransactionBuilder::coinbase()
             .with_output(&address_1, 1000)
@@ -273,7 +273,7 @@ mod test {
             }]
         );
 
-        // Address 2 should receive 1500 Satoshi
+        // Address 2 should receive 1500 koinu
         assert_eq!(
             address_2_utxo_set.into_iter(None).collect::<Vec<_>>(),
             vec![Utxo {

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -599,7 +599,7 @@ mod test {
     }
 
     #[test]
-    fn measures_fees_in_vbytes() {
+    fn measures_fees_in_bytes() {
         let balance = 1000;
         let fee = 1;
         let fee_in_millikoinu = 1000;
@@ -643,7 +643,7 @@ mod test {
         init_state(blocks, stability_threshold);
 
         with_state_mut(|s| {
-            // Coinbase txs are ignored, so the percentiles should be the fee / vbyte of the second transaction.
+            // Coinbase txs are ignored, so the percentiles should be the fee / byte of the second transaction.
             let x = get_current_fee_percentiles_with_number_of_transactions(s, 1);
             let fee_per_total_size = fee_in_millikoinu / tx.total_size() as u64;
             let fee_per_vsize = fee_in_millikoinu / tx.vsize() as u64;

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -5,14 +5,14 @@ use crate::{
     unstable_blocks::{self, UnstableBlocks},
     verify_has_enough_cycles, with_state, with_state_mut,
 };
-use ic_doge_interface::MillisatoshiPerByte;
+use ic_doge_interface::MillikoinuPerByte;
 use ic_doge_types::{Block, Transaction};
 
 /// The number of transactions to include in the percentiles calculation.
 const NUM_TRANSACTIONS: u32 = 10_000;
 
 /// Returns the 100 fee percentiles of the chain's 10,000 most recent transactions.
-pub fn get_current_fee_percentiles() -> Vec<MillisatoshiPerByte> {
+pub fn get_current_fee_percentiles() -> Vec<MillikoinuPerByte> {
     verify_has_enough_cycles(with_state(|s| s.fees.get_current_fee_percentiles_maximum));
     charge_cycles(with_state(|s| s.fees.get_current_fee_percentiles));
 
@@ -34,14 +34,14 @@ pub fn get_current_fee_percentiles() -> Vec<MillisatoshiPerByte> {
     res
 }
 
-pub(crate) fn get_current_fee_percentiles_impl(state: &mut State) -> Vec<MillisatoshiPerByte> {
+pub(crate) fn get_current_fee_percentiles_impl(state: &mut State) -> Vec<MillikoinuPerByte> {
     get_current_fee_percentiles_with_number_of_transactions(state, NUM_TRANSACTIONS)
 }
 
 fn get_current_fee_percentiles_with_number_of_transactions(
     state: &mut State,
     number_of_transactions: u32,
-) -> Vec<MillisatoshiPerByte> {
+) -> Vec<MillikoinuPerByte> {
     let main_chain = unstable_blocks::get_main_chain(&state.unstable_blocks);
     let tip_block_hash = main_chain.tip().block_hash();
 
@@ -85,7 +85,7 @@ fn get_fees_per_byte(
     main_chain: Vec<&Block>,
     unstable_blocks: &UnstableBlocks,
     number_of_transactions: u32,
-) -> Vec<MillisatoshiPerByte> {
+) -> Vec<MillikoinuPerByte> {
     let mut fees = Vec::new();
     let mut tx_i = 0;
     for block in main_chain.iter().rev() {
@@ -111,28 +111,28 @@ fn get_fees_per_byte(
 fn get_tx_fee_per_byte(
     tx: &Transaction,
     unstable_blocks: &UnstableBlocks,
-) -> Option<MillisatoshiPerByte> {
+) -> Option<MillikoinuPerByte> {
     if tx.is_coinbase() {
         // Coinbase transactions do not have a fee.
         return None;
     }
 
-    let mut satoshi = 0;
+    let mut koinu = 0;
     for tx_in in tx.input() {
         let outpoint = (&tx_in.previous_output).into();
-        satoshi += unstable_blocks
+        koinu += unstable_blocks
             .get_tx_out(&outpoint)
             .unwrap_or_else(|| panic!("tx out of outpoint {:?} must exist", outpoint))
             .0
             .value;
     }
     for tx_out in tx.output() {
-        satoshi -= tx_out.value.to_sat();
+        koinu -= tx_out.value.to_sat();
     }
 
     if tx.vsize() > 0 {
         // Don't use floating point division to avoid non-determinism.
-        Some(((1000 * satoshi) / tx.vsize() as u64) as MillisatoshiPerByte)
+        Some(((1000 * koinu) / tx.vsize() as u64) as MillikoinuPerByte)
     } else {
         // Calculating fee is not possible for a zero-size invalid transaction.
         None
@@ -172,7 +172,7 @@ mod test {
     };
     use async_std::task::block_on;
     use bitcoin::Witness;
-    use ic_doge_interface::{Fees, InitConfig, Network, Satoshi};
+    use ic_doge_interface::{Fees, InitConfig, Koinu, Network};
     use ic_doge_test_utils::random_p2pkh_address;
     use ic_doge_types::OutPoint;
     use std::iter::FromIterator;
@@ -246,12 +246,12 @@ mod test {
     // - genesis block receives a coinbase transaction on address_1 with initial_balance
     // - follow-up blocks transfer payments from address_1 to address_2 with a specified fee
     // Fee is choosen to be a multiple of transaction size to have round values of fee.
-    fn generate_blocks(initial_balance: Satoshi, number_of_blocks: u32) -> Vec<Block> {
+    fn generate_blocks(initial_balance: Koinu, number_of_blocks: u32) -> Vec<Block> {
         let network = Network::Regtest;
         let doge_network = into_dogecoin_network(network);
         let mut blocks = Vec::new();
 
-        let pay: Satoshi = 1;
+        let pay: Koinu = 1;
         let address_1 = random_p2pkh_address(doge_network).into();
         let address_2 = random_p2pkh_address(doge_network).into();
 
@@ -268,16 +268,16 @@ mod test {
         let mut previous_block = block_0;
 
         for i in 0..number_of_blocks {
-            // For testing purposes every transaction has 1 Satoshi higher fee than the previous one, starting with 0 satoshi.
+            // For testing purposes every transaction has 1 Koinu higher fee than the previous one, starting with 0 koinu.
             // Each fake transaction is 119 bytes in size.
-            // I.e. a sequence of fees [0, 1, 2, 3] satoshi converts to [0, 8, 16, 25] milisatoshi per byte.
+            // I.e. a sequence of fees [0, 1, 2, 3] koinu converts to [0, 8, 16, 25] milikoinu per byte.
             // To estimate initial balance:
             // number_of_blocks * (number_of_blocks + 1) / 2
-            let fee = i as Satoshi;
+            let fee = i as Koinu;
             let change = match balance.checked_sub(pay + fee) {
                 Some(value) => value,
                 None => panic!(
-                    "There is not enough balance of {} Satoshi to perform transaction #{} with fee of {} satoshi",
+                    "There is not enough balance of {} Koinu to perform transaction #{} with fee of {} koinu",
                     balance, i, fee
                 ),
             };
@@ -335,10 +335,10 @@ mod test {
                 number_of_transactions as u32,
             );
 
-            // Initial transactions' fees [0, 1, 2, 3, 4] satoshi, with 119 bytes of transaction size
-            // transfer into [0, 8, 16, 25, 33] millisatoshi per byte fees in chronological order.
+            // Initial transactions' fees [0, 1, 2, 3, 4] koinu, with 119 bytes of transaction size
+            // transfer into [0, 8, 16, 25, 33] millikoinu per byte fees in chronological order.
             assert_eq!(fees.len(), number_of_blocks as usize);
-            // Fees are in a reversed order, in millisatoshi per byte units.
+            // Fees are in a reversed order, in millikoinu per byte units.
             assert_eq!(fees, vec![33, 25, 16, 8, 0]);
         });
 
@@ -355,7 +355,7 @@ mod test {
     fn coinbase_txs_are_ignored() {
         let balance = 1000;
         let fee = 1;
-        let fee_in_millisatoshi = fee * 1000;
+        let fee_in_millikoinu = fee * 1000;
         let network = Network::Regtest;
         let doge_network = into_dogecoin_network(network);
 
@@ -382,7 +382,7 @@ mod test {
             // so the percentiles should be the fee / byte of the second transaction.
             assert_eq!(
                 get_current_fee_percentiles_with_number_of_transactions(s, 1),
-                vec![fee_in_millisatoshi / tx_2.vsize() as u64; PERCENTILE_BUCKETS]
+                vec![fee_in_millikoinu / tx_2.vsize() as u64; PERCENTILE_BUCKETS]
             );
         });
     }
@@ -455,11 +455,11 @@ mod test {
                 &state.unstable_blocks,
                 number_of_transactions,
             );
-            // Initial transactions' fees [0, 1, 2, 3, 4, 5, 6, 7, 8] satoshi, with 119 bytes of transaction size
-            // transfer into [0, 8, 16, 25, 33, 42, 50, 58] millisatoshi per byte fees in chronological order.
+            // Initial transactions' fees [0, 1, 2, 3, 4, 5, 6, 7, 8] koinu, with 119 bytes of transaction size
+            // transfer into [0, 8, 16, 25, 33, 42, 50, 58] millikoinu per byte fees in chronological order.
             // Extracted fees contain only last 4 transaction fees in a reversed order.
             assert_eq!(fees.len(), number_of_transactions as usize);
-            // Fees are in a reversed order, in millisatoshi per byte units.
+            // Fees are in a reversed order, in millikoinu per byte units.
             assert_eq!(fees, vec![58, 50, 42, 33]);
 
             let percentiles = get_current_fee_percentiles_with_number_of_transactions(state, 4);
@@ -492,10 +492,10 @@ mod test {
                 number_of_transactions,
             );
 
-            // Initial transactions' fees [0, 1, 2, 3, 4] satoshi, with 119 bytes of transaction size
-            // transfer into [0, 8, 16, 25, 33] millisatoshi per byte fees in chronological order.
+            // Initial transactions' fees [0, 1, 2, 3, 4] koinu, with 119 bytes of transaction size
+            // transfer into [0, 8, 16, 25, 33] millikoinu per byte fees in chronological order.
             assert_eq!(fees.len(), number_of_blocks as usize);
-            // Fees are in a reversed order, in millisatoshi per byte units.
+            // Fees are in a reversed order, in millikoinu per byte units.
             assert_eq!(fees, vec![33, 25, 16, 8, 0]);
 
             assert_eq!(percentiles.len(), PERCENTILE_BUCKETS);
@@ -546,13 +546,13 @@ mod test {
                 number_of_transactions,
             );
 
-            // Initial transactions' fees [0, 1, 2, 3, 4] satoshi, with 119 bytes of transaction size
-            // transfer into [0, 8, 16, 25, 33] millisatoshi per byte fees in chronological order.
+            // Initial transactions' fees [0, 1, 2, 3, 4] koinu, with 119 bytes of transaction size
+            // transfer into [0, 8, 16, 25, 33] millikoinu per byte fees in chronological order.
             // But only 2 last transactions are placed in unstable blocks that form a main chain.
             // All the rest of the blocks are partially stored in UTXO set, which does not have information
             // about the sequence and input values, which does not allow to compute the fee.
             assert_eq!(fees.len(), 2);
-            // Fees are in a reversed order, in millisatoshi per byte units.
+            // Fees are in a reversed order, in millikoinu per byte units.
             assert_eq!(fees, vec![33, 25]);
         });
 
@@ -602,7 +602,7 @@ mod test {
     fn measures_fees_in_vbytes() {
         let balance = 1000;
         let fee = 1;
-        let fee_in_millisatoshi = 1000;
+        let fee_in_millikoinu = 1000;
         let network = Network::Regtest;
         let doge_network = into_dogecoin_network(network);
 
@@ -645,8 +645,8 @@ mod test {
         with_state_mut(|s| {
             // Coinbase txs are ignored, so the percentiles should be the fee / vbyte of the second transaction.
             let x = get_current_fee_percentiles_with_number_of_transactions(s, 1);
-            let fee_per_total_size = fee_in_millisatoshi / tx.total_size() as u64;
-            let fee_per_vsize = fee_in_millisatoshi / tx.vsize() as u64;
+            let fee_per_total_size = fee_in_millikoinu / tx.total_size() as u64;
+            let fee_per_vsize = fee_in_millikoinu / tx.vsize() as u64;
             assert_ne!(x, vec![fee_per_total_size; PERCENTILE_BUCKETS]);
             assert_eq!(x, vec![fee_per_vsize; PERCENTILE_BUCKETS]);
         });

--- a/canister/src/api/get_balance.rs
+++ b/canister/src/api/get_balance.rs
@@ -4,7 +4,7 @@ use crate::{
     types::{Address, GetBalanceRequest},
     unstable_blocks, verify_has_enough_cycles, with_state, with_state_mut,
 };
-use ic_doge_interface::{GetBalanceError, Satoshi};
+use ic_doge_interface::{GetBalanceError, Koinu};
 use std::str::FromStr;
 
 // Various profiling stats for tracking the performance of `get_balance`.
@@ -18,7 +18,7 @@ struct Stats {
 }
 
 /// Retrieves the balance of the given Dogecoin address.
-pub fn get_balance(request: GetBalanceRequest) -> Result<Satoshi, GetBalanceError> {
+pub fn get_balance(request: GetBalanceRequest) -> Result<Koinu, GetBalanceError> {
     verify_has_enough_cycles(with_state(|s| s.fees.get_balance_maximum));
     charge_cycles(with_state(|s| s.fees.get_balance));
 
@@ -27,17 +27,17 @@ pub fn get_balance(request: GetBalanceRequest) -> Result<Satoshi, GetBalanceErro
 
 /// Retrieves the balance of the given Dogecoin address,
 /// while not charging for the execution, used only for queries.
-pub fn get_balance_query(request: GetBalanceRequest) -> Result<Satoshi, GetBalanceError> {
+pub fn get_balance_query(request: GetBalanceRequest) -> Result<Koinu, GetBalanceError> {
     get_balance_private(request)
 }
 
-fn get_balance_private(request: GetBalanceRequest) -> Result<Satoshi, GetBalanceError> {
+fn get_balance_private(request: GetBalanceRequest) -> Result<Koinu, GetBalanceError> {
     let min_confirmations = request.min_confirmations.unwrap_or(0);
     let address =
         Address::from_str(&request.address).map_err(|_| GetBalanceError::MalformedAddress)?;
 
     // NOTE: It is safe to sum up the balances here without the risk of overflow.
-    // The maximum number of bitcoins is 2.1 * 10^7, which is 2.1* 10^15 satoshis.
+    // The maximum number of bitcoins is 2.1 * 10^7, which is 2.1* 10^15 koinus.
     // That is well below the max value of a `u64`.
     let (balance, stats) = with_state(|state| {
         // Retrieve the balance that's pre-computed for stable blocks.
@@ -160,7 +160,7 @@ mod test {
             ..Default::default()
         });
 
-        // Create a block where 1000 satoshis are given to an address.
+        // Create a block where 1000 koinus are given to an address.
         let address = random_p2pkh_address(doge_network).into();
         let coinbase_tx = TransactionBuilder::coinbase()
             .with_output(&address, 1000)
@@ -245,8 +245,8 @@ mod test {
         let address_1 = random_p2pkh_address(doge_network).into();
         let address_2 = random_p2pkh_address(doge_network).into();
 
-        // Create a chain where 1000 satoshis are given to the address_1, then
-        // address_1 gives 1000 satoshis to address_2.
+        // Create a chain where 1000 koinus are given to the address_1, then
+        // address_1 gives 1000 koinus to address_2.
         let coinbase_tx = TransactionBuilder::coinbase()
             .with_output(&address_1, 1000)
             .build();

--- a/canister/src/api/get_utxos.rs
+++ b/canister/src/api/get_utxos.rs
@@ -366,7 +366,7 @@ mod test {
         // Generate an address.
         let address = random_p2pkh_address(doge_network).into();
 
-        // Create a block where 1000 satoshis are given to the address.
+        // Create a block where 1000 koinus are given to the address.
         let coinbase_tx = TransactionBuilder::coinbase()
             .with_output(&address, 1000)
             .build();
@@ -514,8 +514,8 @@ mod test {
 
         let address_2 = random_p2pkh_address(doge_network).into();
 
-        // Create a block where 1000 satoshis are given to the address_1, followed
-        // by a block where address_1 gives 1000 satoshis to address_2.
+        // Create a block where 1000 koinus are given to the address_1, followed
+        // by a block where address_1 gives 1000 koinus to address_2.
         let coinbase_tx = TransactionBuilder::coinbase()
             .with_output(&address_1, 1000)
             .build();
@@ -663,7 +663,7 @@ mod test {
         let address_3 = random_p2pkh_address(doge_network).into();
         let address_4 = random_p2pkh_address(doge_network).into();
 
-        // Create a genesis block where 1000 satoshis are given to address 1.
+        // Create a genesis block where 1000 koinus are given to address 1.
         let coinbase_tx = TransactionBuilder::coinbase()
             .with_output(&address_1, 1000)
             .build();
@@ -706,7 +706,7 @@ mod test {
             block_0_utxos
         );
 
-        // Extend block 0 with block 1 that spends the 1000 satoshis and gives them to address 2.
+        // Extend block 0 with block 1 that spends the 1000 koinus and gives them to address 2.
         let tx = TransactionBuilder::new()
             .with_input(ic_doge_types::OutPoint::new(coinbase_tx.txid(), 0))
             .with_output(&address_2, 1000)
@@ -755,7 +755,7 @@ mod test {
             }
         );
 
-        // Extend block 0 (again) with block 1 that spends the 1000 satoshis to address 3
+        // Extend block 0 (again) with block 1 that spends the 1000 koinus to address 3
         // This causes a fork.
         let tx = TransactionBuilder::new()
             .with_input(ic_doge_types::OutPoint::new(coinbase_tx.txid(), 0))
@@ -890,7 +890,7 @@ mod test {
 
         let address_1 = random_p2pkh_address(doge_network).into();
 
-        // Create a block where 1000 satoshis are given to the address_1.
+        // Create a block where 1000 koinus are given to the address_1.
         let tx = TransactionBuilder::coinbase()
             .with_output(&address_1, 1000)
             .build();
@@ -965,8 +965,8 @@ mod test {
 
         let address_2 = random_p2pkh_address(doge_network).into();
 
-        // Create a genesis block where 1000 satoshis are given to the address_1, followed
-        // by a block where address_1 gives 1000 satoshis to address_2.
+        // Create a genesis block where 1000 koinus are given to the address_1, followed
+        // by a block where address_1 gives 1000 koinus to address_2.
         let coinbase_tx = TransactionBuilder::coinbase()
             .with_output(&address_1, 1000)
             .build();

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -643,7 +643,7 @@ mod test {
                     min_confirmations: None
                 })
                 .unwrap(),
-                tx_cardinality as u64 * 1000
+                tx_cardinality as u128 * 1000
             );
         }
 
@@ -674,7 +674,7 @@ mod test {
                 min_confirmations: None
             })
             .unwrap(),
-            tx_cardinality as u64 * 1000
+            tx_cardinality as u128 * 1000
         );
     }
 

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -31,7 +31,7 @@ pub use heartbeat::heartbeat;
 use ic_doge_interface::{
     Config, Flag, GetBalanceError, GetBalanceRequest, GetBlockHeadersError, GetBlockHeadersRequest,
     GetBlockHeadersResponse, GetCurrentFeePercentilesRequest, GetUtxosError, GetUtxosRequest,
-    GetUtxosResponse, InitConfig, MillisatoshiPerByte, Network, Satoshi, SetConfigRequest,
+    GetUtxosResponse, InitConfig, Koinu, MillikoinuPerByte, Network, SetConfigRequest,
 };
 use ic_doge_types::Block;
 use ic_stable_structures::Memory;
@@ -113,21 +113,21 @@ pub fn init(init_config: InitConfig) {
 
 pub fn get_current_fee_percentiles(
     request: GetCurrentFeePercentilesRequest,
-) -> Vec<MillisatoshiPerByte> {
+) -> Vec<MillikoinuPerByte> {
     verify_api_access();
     verify_network(request.network.into());
     verify_synced();
     api::get_current_fee_percentiles()
 }
 
-pub fn get_balance(request: GetBalanceRequest) -> Result<Satoshi, GetBalanceError> {
+pub fn get_balance(request: GetBalanceRequest) -> Result<Koinu, GetBalanceError> {
     verify_api_access();
     verify_network(request.network.into());
     verify_synced();
     api::get_balance(request.into())
 }
 
-pub fn get_balance_query(request: GetBalanceRequest) -> Result<Satoshi, GetBalanceError> {
+pub fn get_balance_query(request: GetBalanceRequest) -> Result<Koinu, GetBalanceError> {
     verify_api_access();
     verify_network(request.network.into());
     verify_synced();

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -31,7 +31,7 @@ pub use heartbeat::heartbeat;
 use ic_doge_interface::{
     Config, Flag, GetBalanceError, GetBalanceRequest, GetBlockHeadersError, GetBlockHeadersRequest,
     GetBlockHeadersResponse, GetCurrentFeePercentilesRequest, GetUtxosError, GetUtxosRequest,
-    GetUtxosResponse, InitConfig, Koinu, MillikoinuPerByte, Network, SetConfigRequest,
+    GetUtxosResponse, InitConfig, MillikoinuPerByte, Network, SetConfigRequest,
 };
 use ic_doge_types::Block;
 use ic_stable_structures::Memory;
@@ -120,14 +120,14 @@ pub fn get_current_fee_percentiles(
     api::get_current_fee_percentiles()
 }
 
-pub fn get_balance(request: GetBalanceRequest) -> Result<Koinu, GetBalanceError> {
+pub fn get_balance(request: GetBalanceRequest) -> Result<u128, GetBalanceError> {
     verify_api_access();
     verify_network(request.network.into());
     verify_synced();
     api::get_balance(request.into())
 }
 
-pub fn get_balance_query(request: GetBalanceRequest) -> Result<Koinu, GetBalanceError> {
+pub fn get_balance_query(request: GetBalanceRequest) -> Result<u128, GetBalanceError> {
     verify_api_access();
     verify_network(request.network.into());
     verify_synced();

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -7,7 +7,7 @@ use ic_doge_interface::{
     MillikoinuPerByte, SendTransactionRequest, SetConfigRequest,
 };
 
-/// Use Nat to represent an arbitrary amount of Koinus because the total amount of DOGE 
+/// Use Nat to represent an arbitrary amount of Koinus because the total amount of DOGE
 /// will exceed the bound of u64 by around year 2030.
 type Amount = candid::Nat;
 

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -3,8 +3,8 @@ use ic_cdk_macros::{heartbeat, init, inspect_message, post_upgrade, pre_upgrade,
 use ic_doge_canister::types::{HttpRequest, HttpResponse};
 use ic_doge_interface::{
     Config, GetBalanceRequest, GetBlockHeadersRequest, GetBlockHeadersResponse,
-    GetCurrentFeePercentilesRequest, GetUtxosRequest, GetUtxosResponse, InitConfig,
-    MillisatoshiPerByte, Satoshi, SendTransactionRequest, SetConfigRequest,
+    GetCurrentFeePercentilesRequest, GetUtxosRequest, GetUtxosResponse, InitConfig, Koinu,
+    MillikoinuPerByte, SendTransactionRequest, SetConfigRequest,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -38,7 +38,7 @@ async fn heartbeat() {
 }
 
 #[update(manual_reply = true)]
-pub fn dogecoin_get_balance(request: GetBalanceRequest) -> ManualReply<Satoshi> {
+pub fn dogecoin_get_balance(request: GetBalanceRequest) -> ManualReply<Koinu> {
     match ic_doge_canister::get_balance(request) {
         Ok(response) => ManualReply::one(response),
         Err(e) => ManualReply::reject(format!("get_balance failed: {:?}", e).as_str()),
@@ -46,7 +46,7 @@ pub fn dogecoin_get_balance(request: GetBalanceRequest) -> ManualReply<Satoshi> 
 }
 
 #[query(manual_reply = true)]
-pub fn dogecoin_get_balance_query(request: GetBalanceRequest) -> ManualReply<Satoshi> {
+pub fn dogecoin_get_balance_query(request: GetBalanceRequest) -> ManualReply<Koinu> {
     if ic_cdk::api::data_certificate().is_none() {
         return ManualReply::reject("get_balance_query cannot be called in replicated mode");
     }
@@ -96,7 +96,7 @@ async fn dogecoin_send_transaction(request: SendTransactionRequest) -> ManualRep
 #[update]
 pub fn dogecoin_get_current_fee_percentiles(
     request: GetCurrentFeePercentilesRequest,
-) -> Vec<MillisatoshiPerByte> {
+) -> Vec<MillikoinuPerByte> {
     ic_doge_canister::get_current_fee_percentiles(request)
 }
 

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -3,9 +3,13 @@ use ic_cdk_macros::{heartbeat, init, inspect_message, post_upgrade, pre_upgrade,
 use ic_doge_canister::types::{HttpRequest, HttpResponse};
 use ic_doge_interface::{
     Config, GetBalanceRequest, GetBlockHeadersRequest, GetBlockHeadersResponse,
-    GetCurrentFeePercentilesRequest, GetUtxosRequest, GetUtxosResponse, InitConfig, Koinu,
+    GetCurrentFeePercentilesRequest, GetUtxosRequest, GetUtxosResponse, InitConfig,
     MillikoinuPerByte, SendTransactionRequest, SetConfigRequest,
 };
+
+/// Use Nat to represent amount of Koinus because the total amount of DOGE will exceed the
+/// limit u64 by around year 2030.
+type Amount = candid::Nat;
 
 #[cfg(target_arch = "wasm32")]
 mod printer;
@@ -38,20 +42,20 @@ async fn heartbeat() {
 }
 
 #[update(manual_reply = true)]
-pub fn dogecoin_get_balance(request: GetBalanceRequest) -> ManualReply<Koinu> {
+pub fn dogecoin_get_balance(request: GetBalanceRequest) -> ManualReply<Amount> {
     match ic_doge_canister::get_balance(request) {
-        Ok(response) => ManualReply::one(response),
+        Ok(response) => ManualReply::one(Amount::from(response)),
         Err(e) => ManualReply::reject(format!("get_balance failed: {:?}", e).as_str()),
     }
 }
 
 #[query(manual_reply = true)]
-pub fn dogecoin_get_balance_query(request: GetBalanceRequest) -> ManualReply<Koinu> {
+pub fn dogecoin_get_balance_query(request: GetBalanceRequest) -> ManualReply<Amount> {
     if ic_cdk::api::data_certificate().is_none() {
         return ManualReply::reject("get_balance_query cannot be called in replicated mode");
     }
     match ic_doge_canister::get_balance_query(request) {
-        Ok(response) => ManualReply::one(response),
+        Ok(response) => ManualReply::one(Amount::from(response)),
         Err(e) => ManualReply::reject(format!("get_balance_query failed: {:?}", e).as_str()),
     }
 }

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -7,8 +7,8 @@ use ic_doge_interface::{
     MillikoinuPerByte, SendTransactionRequest, SetConfigRequest,
 };
 
-/// Use Nat to represent amount of Koinus because the total amount of DOGE will exceed the
-/// limit u64 by around year 2030.
+/// Use Nat to represent an arbitrary amount of Koinus because the total amount of DOGE 
+/// will exceed the limit u64 by around year 2030.
 type Amount = candid::Nat;
 
 #[cfg(target_arch = "wasm32")]

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -8,7 +8,7 @@ use ic_doge_interface::{
 };
 
 /// Use Nat to represent an arbitrary amount of Koinus because the total amount of DOGE 
-/// will exceed the limit u64 by around year 2030.
+/// will exceed the bound of u64 by around year 2030.
 type Amount = candid::Nat;
 
 #[cfg(target_arch = "wasm32")]

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use bitcoin::{consensus::Decodable, dogecoin::Header};
 use candid::Principal;
-use ic_doge_interface::{Fees, Flag, Height, MillisatoshiPerByte, Network};
+use ic_doge_interface::{Fees, Flag, Height, MillikoinuPerByte, Network};
 use ic_doge_types::{Block, BlockHash, OutPoint};
 use ic_doge_validation::{
     AuxPowHeaderValidator, DogecoinHeaderValidator, ValidateHeaderError as InsertBlockError,
@@ -283,7 +283,7 @@ const TX_OUT_SCRIPT_MAX_SIZE_SMALL: u32 = 25;
 // The maximum size in bytes of a bitcoin script for it to be considered "medium".
 const TX_OUT_SCRIPT_MAX_SIZE_MEDIUM: u32 = 201;
 
-// A transaction output's value in satoshis is a `u64`, which is 8 bytes.
+// A transaction output's value in koinus is a `u64`, which is 8 bytes.
 const TX_OUT_VALUE_SIZE: u32 = 8;
 
 const TX_OUT_MAX_SIZE_SMALL: u32 = TX_OUT_SCRIPT_MAX_SIZE_SMALL + TX_OUT_VALUE_SIZE;
@@ -445,7 +445,7 @@ impl SuccessorsResponseStats {
 #[derive(Default, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct FeePercentilesCache {
     pub tip_block_hash: BlockHash,
-    pub fee_percentiles: Vec<MillisatoshiPerByte>,
+    pub fee_percentiles: Vec<MillikoinuPerByte>,
 }
 
 #[cfg(test)]

--- a/canister/src/types.rs
+++ b/canister/src/types.rs
@@ -6,8 +6,8 @@ use candid::CandidType;
 use datasize::DataSize;
 use ic_doge_interface::{
     Address as AddressStr, GetBalanceRequest as PublicGetBalanceRequest,
-    GetUtxosRequest as PublicGetUtxosRequest, Height, Network, NetworkAdapter, Satoshi,
-    UtxosFilter, UtxosFilterInRequest,
+    GetUtxosRequest as PublicGetUtxosRequest, Height, Koinu, Network, NetworkAdapter, UtxosFilter,
+    UtxosFilterInRequest,
 };
 use ic_doge_types::{BlockHash, OutPoint, Txid};
 use ic_stable_structures::{
@@ -540,7 +540,7 @@ pub enum Slicing<T, U> {
 pub struct Utxo {
     pub height: u32,
     pub outpoint: OutPoint,
-    pub value: Satoshi,
+    pub value: Koinu,
 }
 
 impl Ord for Utxo {

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -5,7 +5,7 @@ use crate::{
     types::{Address, AddressUtxo, AddressUtxoRange, Slicing, TxOut, Utxo},
 };
 use bitcoin::{Script, TxOut as BitcoinTxOut};
-use ic_doge_interface::{Height, Network, Satoshi};
+use ic_doge_interface::{Height, Koinu, Network};
 use ic_doge_types::{Block, BlockHash, OutPoint, Transaction, Txid};
 use ic_stable_structures::{storable::Blob, StableBTreeMap, Storable as _};
 use serde::{Deserialize, Serialize};
@@ -155,7 +155,7 @@ impl UtxoSet {
     }
 
     /// Returns the balance of the given address.
-    pub fn get_balance(&self, address: &Address) -> Satoshi {
+    pub fn get_balance(&self, address: &Address) -> Koinu {
         let mut balance = self.balances.get(address).unwrap_or(0);
 
         // Revert any changes to the balance that were done by the ingesting block.
@@ -437,7 +437,7 @@ impl UtxoSet {
     }
 
     #[cfg(test)]
-    pub fn get_total_supply(&self) -> Satoshi {
+    pub fn get_total_supply(&self) -> Koinu {
         self.utxos.iter().map(|(_, (v, _))| v.value).sum()
     }
 }
@@ -971,7 +971,7 @@ mod test {
 
             let mut utxo_set = UtxoSet::new(network);
 
-            // Transaction 0: A coinbase tx with `tx_cardinality` inputs, each giving 1 Satoshi to
+            // Transaction 0: A coinbase tx with `tx_cardinality` inputs, each giving 1 Koinu to
             // address 1.
             let mut tx_0 = TransactionBuilder::coinbase();
             for i in 0..tx_cardinality {

--- a/e2e-tests/disable-api-if-not-fully-synced-flag.sh
+++ b/e2e-tests/disable-api-if-not-fully-synced-flag.sh
@@ -130,7 +130,7 @@ BALANCE=$(dfx canister call dogecoin dogecoin_get_balance '(record {
   address = "mhXcJVuNA48bZsrKq4t21jx1neSqyceqTM"
 })')
 
-if ! [[ $BALANCE = "(2 : nat64)" ]]; then
+if ! [[ $BALANCE = "(2 : nat)" ]]; then
   echo "FAIL"
   exit 1
 fi

--- a/e2e-tests/scenario-1.sh
+++ b/e2e-tests/scenario-1.sh
@@ -28,7 +28,7 @@ BALANCE=$(dfx canister call dogecoin dogecoin_get_balance '(record {
   address = "mhXcJVuNA48bZsrKq4t21jx1neSqyceqTM"
 })')
 
-if ! [[ $BALANCE = "(0 : nat64)" ]]; then
+if ! [[ $BALANCE = "(0 : nat)" ]]; then
   echo "FAIL"
   exit 1
 fi
@@ -38,7 +38,7 @@ BALANCE=$(dfx canister call --query dogecoin dogecoin_get_balance_query '(record
   address = "mhXcJVuNA48bZsrKq4t21jx1neSqyceqTM"
 })')
 
-if ! [[ $BALANCE = "(0 : nat64)" ]]; then
+if ! [[ $BALANCE = "(0 : nat)" ]]; then
   echo "FAIL"
   exit 1
 fi
@@ -51,7 +51,7 @@ BALANCE=$(dfx canister call dogecoin dogecoin_get_balance '(record {
 })')
 
 # Verify that the balance is 50 DOGE.
-if ! [[ $BALANCE = "(5_000_000_000 : nat64)" ]]; then
+if ! [[ $BALANCE = "(5_000_000_000 : nat)" ]]; then
   echo "FAIL"
   exit 1
 fi
@@ -125,7 +125,7 @@ BALANCE=$(dfx canister call --query dogecoin dogecoin_get_balance_query '(record
   address = "mjCLh7tvtg92WfVgqBbqFd2DoJ86Jr6dFW";
 })')
 
-if ! [[ $BALANCE = "(5_000_000_000 : nat64)" ]]; then
+if ! [[ $BALANCE = "(5_000_000_000 : nat)" ]]; then
   echo "FAIL"
   exit 1
 fi
@@ -148,7 +148,7 @@ BALANCE=$(dfx canister call dogecoin dogecoin_get_balance '(record {
   address = "mjCLh7tvtg92WfVgqBbqFd2DoJ86Jr6dFW";
 })')
 
-if ! [[ $BALANCE = "(5_000_000_000 : nat64)" ]]; then
+if ! [[ $BALANCE = "(5_000_000_000 : nat)" ]]; then
   echo "FAIL"
   exit 1
 fi
@@ -158,7 +158,7 @@ BALANCE=$(dfx canister call --query dogecoin dogecoin_get_balance_query '(record
   address = "mjCLh7tvtg92WfVgqBbqFd2DoJ86Jr6dFW";
 })')
 
-if ! [[ $BALANCE = "(5_000_000_000 : nat64)" ]]; then
+if ! [[ $BALANCE = "(5_000_000_000 : nat)" ]]; then
   echo "FAIL"
   exit 1
 fi

--- a/e2e-tests/scenario-2.sh
+++ b/e2e-tests/scenario-2.sh
@@ -31,7 +31,7 @@ BALANCE=$(dfx canister call dogecoin dogecoin_get_balance '(record {
   address = "mhXcJVuNA48bZsrKq4t21jx1neSqyceqTM"
 })')
 
-if ! [[ $BALANCE = "(40_000 : nat64)" ]]; then
+if ! [[ $BALANCE = "(40_000 : nat)" ]]; then
   echo "FAIL"
   exit 1
 fi

--- a/e2e-tests/scenario-2/src/main.rs
+++ b/e2e-tests/scenario-2/src/main.rs
@@ -85,7 +85,7 @@ fn init() {
     for _ in 0..NUM_BLOCKS {
         let mut block = BlockBuilder::default().with_prev_header(*prev_header);
         for i in lock_time_offset..lock_time_offset + TXS_PER_BLOCK {
-            // A transaction giving 1 satoshi to the address.
+            // A transaction giving 1 koinu to the address.
             block = block.with_transaction(
                 TransactionBuilder::new()
                     .with_lock_time(i)

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -8,8 +8,8 @@ use std::fmt;
 use std::str::FromStr;
 
 pub type Address = String;
-pub type Satoshi = u64;
-pub type MillisatoshiPerByte = u64;
+pub type Koinu = u64;
+pub type MillikoinuPerByte = u64;
 pub type BlockHash = Vec<u8>;
 pub type Height = u32;
 pub type Page = ByteBuf;
@@ -329,7 +329,7 @@ pub struct OutPoint {
 #[derive(CandidType, Debug, Deserialize, PartialEq, Serialize, Clone, Hash, Eq)]
 pub struct Utxo {
     pub outpoint: OutPoint,
-    pub value: Satoshi,
+    pub value: Koinu,
     pub height: Height,
 }
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -364,9 +364,9 @@ impl TransactionBuilder {
         self
     }
 
-    pub fn with_output(mut self, address: &Address, satoshi: u64) -> Self {
+    pub fn with_output(mut self, address: &Address, koinu: u64) -> Self {
         self.output.push(TxOut {
-            value: Amount::from_sat(satoshi),
+            value: Amount::from_sat(koinu),
             script_pubkey: address.script_pubkey(),
         });
         self


### PR DESCRIPTION
XC-492: DOGE canister: user balance and UTXO value may overflow a u64 in 5 years

Because the total value of DOGE is going to exceed the bound of u64 at around 2030, it is safer to use nat to represent an arbitrary amount of DOGE, e.g., the return value of get_balance calls.

The value in a UTXO can remain u64 because it is bound by the protocol to be [no more than 10B DOGE](https://github.com/dogecoin/dogecoin/blob/2c513d0172e8bc86fe9a337693b26f2fdf68a013/src/primitives/transaction.cpp#L89), which translates to 10^18 koinus (smallest unit of DOGE), still within the bound of u64.