### PR TITLE
feat: store auxpow headers into stable memory

### DIFF
--- a/canister/src/block_header_store.rs
+++ b/canister/src/block_header_store.rs
@@ -46,7 +46,7 @@ impl BlockHeaderStore {
         let block_hash = block.block_hash();
         let mut header_blob = vec![];
         block
-            .header()
+            .auxpow_header()
             .consensus_encode(&mut header_blob)
             .expect("block header must be valid");
 

--- a/canister/src/block_header_store.rs
+++ b/canister/src/block_header_store.rs
@@ -101,7 +101,6 @@ fn init_block_heights() -> StableBTreeMap<u32, BlockHash, Memory> {
 #[cfg(test)]
 mod test {
     use bitcoin::consensus::Encodable;
-    use datasize::DataSize;
     use proptest::proptest;
 
     use crate::test_utils::BlockChainBuilder;

--- a/canister/src/block_header_store.rs
+++ b/canister/src/block_header_store.rs
@@ -101,8 +101,10 @@ fn init_block_heights() -> StableBTreeMap<u32, BlockHash, Memory> {
 #[cfg(test)]
 mod test {
     use bitcoin::consensus::Encodable;
+    use datasize::DataSize;
     use proptest::proptest;
 
+    use crate::test_utils::BlockChainBuilder;
     use crate::{
         block_header_store::BlockHeaderStore, test_utils::BlockBuilder, types::BlockHeaderBlob,
     };
@@ -111,15 +113,17 @@ mod test {
     fn test_get_block_headers_in_range() {
         let mut headers = vec![];
         let block_0 = BlockBuilder::genesis().build();
-        headers.push(*block_0.header());
+        headers.push(block_0.auxpow_header().clone());
 
         let mut store = BlockHeaderStore::init();
         store.insert_block(&block_0, 0);
         let block_num = 100;
 
         for i in 1..block_num {
-            let block = BlockBuilder::with_prev_header(&headers[i - 1]).build();
-            headers.push(*block.header());
+            let block = BlockBuilder::with_prev_header(&headers[i - 1])
+                .with_auxpow(true)
+                .build();
+            headers.push(block.auxpow_header().clone());
             store.insert_block(&block, i as u32);
         }
 
@@ -142,5 +146,27 @@ mod test {
                 }
             }
         );
+    }
+
+    #[test]
+    fn test_auxpow_header_stored() {
+        let block_num = 10;
+        let blockchain = BlockChainBuilder::new(block_num).with_auxpow().build();
+
+        let mut store = BlockHeaderStore::init();
+        for i in 0..block_num {
+            store.insert_block(&blockchain[i as usize], i);
+        }
+
+        for header in store.get_block_headers_in_range(std::ops::RangeInclusive::new(1, block_num))
+        {
+            let header_bytes: Vec<u8> = header.into();
+            let header_bytes_len = header_bytes.len();
+            assert!(
+                header_bytes_len > 80,
+                "Stored header should be AuxPow header, i.e. larger than 80 bytes, got {} bytes",
+                header_bytes_len
+            );
+        }
     }
 }


### PR DESCRIPTION
[XC-486](https://dfinity.atlassian.net/browse/XC-486?atlOrigin=eyJpIjoiYzlkMTFiOTU1YzgyNDYyYzg0NWM2YWJkMWRmMmU1MTIiLCJwIjoiaiJ9): Store AuxPow header into stable memory instead of pure 80-byte headers without AuxPow information. This might increase the storage cost by a couple of GB but would benefit auditing the correctness of headers since AuxPow information is needed to validate headers.

[XC-486]: https://dfinity.atlassian.net/browse/XC-486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ