### PR TITLE
feat: ensure `get_block_header` endpoint returns 80-bytes headers

### DIFF
--- a/canister/src/block_header_store.rs
+++ b/canister/src/block_header_store.rs
@@ -118,11 +118,11 @@ mod test {
     use bitcoin::consensus::Encodable;
     use proptest::proptest;
 
+    use crate::block_header_store::deserialize_block_header;
     use crate::test_utils::BlockChainBuilder;
     use crate::{
         block_header_store::BlockHeaderStore, test_utils::BlockBuilder, types::BlockHeaderBlob,
     };
-    use crate::block_header_store::deserialize_block_header;
 
     #[test]
     fn test_get_block_headers_in_range() {
@@ -190,21 +190,21 @@ mod test {
     fn test_serialize_deserialize_header_from_auxpow_header() {
         // Create a block with AuxPoW enabled
         let auxpow_block = BlockBuilder::genesis().with_auxpow(true).build();
-        
+
         // Serialize the pure header (without AuxPoW)
         let mut pure_header_bytes = vec![];
         auxpow_block
             .header()
             .consensus_encode(&mut pure_header_bytes)
             .unwrap();
-        
+
         // Serialize the AuxPoW header (with AuxPoW)
         let mut auxpow_header_bytes = vec![];
         auxpow_block
             .auxpow_header()
             .consensus_encode(&mut auxpow_header_bytes)
             .unwrap();
-        
+
         // Verify that pure header is exactly 80 bytes
         assert_eq!(
             pure_header_bytes.len(),
@@ -212,19 +212,18 @@ mod test {
             "Pure header should be exactly 80 bytes, got {}",
             pure_header_bytes.len()
         );
-        
+
         // Verify that AuxPoW header is larger than 80 bytes
         assert!(
             auxpow_header_bytes.len() > 80,
             "AuxPoW header should be larger than 80 bytes, got {}",
             auxpow_header_bytes.len()
         );
-        
+
         // Verify that the first 80 bytes of the AuxPoW header are identical to the pure header
         let auxpow_prefix = &auxpow_header_bytes[0..80];
         assert_eq!(
-            pure_header_bytes,
-            auxpow_prefix,
+            pure_header_bytes, auxpow_prefix,
             "First 80 bytes of serialized AuxPoW header should match pure header serialization"
         );
 

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -211,7 +211,7 @@ impl UnstableBlocks {
         chain
     }
 
-    /// Returns block headers of all unstable blocks in height range `heights`.
+    /// Returns block headers (without AuxPow information) of all unstable blocks in height range `heights`.
     pub fn get_block_headers_in_range(
         &self,
         stable_height: Height,


### PR DESCRIPTION
Ensures that `get_block_headers_in_range` endpoint returns 80-byte headers (no AuxPow information) which was not the case until now (credits to @gregorydemay for pointing this out!). 

The `get_block_headers_in_range` method in `src/block_header_store.rs` was returning AuxPow header. This method has now been renamed to `get_auxpow_block_headers_in_range`. A new method `get_block_headers_in_range` is introduced and used in `get_block_headers_internal` to return pure header information from the (stable) `BlockHeaderStore`. The naming is now consistent with the method `get_block_headers_in_range` defined in `src/unstable_blocks.rs` which also returns pure header information (and is used in `get_block_headers_internal` too).