### PR TITLE
chore(bootstrap): disable block and auxpow pruning

### DIFF
--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -33,14 +33,14 @@ tar -xvf dogecoin-1.14.9-x86_64-linux-gnu.tar.gz
 
 ```shell
 DOGECOIN_DIR=./dogecoin-1.14.9
-NETWORK=<mainnet or testnet>
+NETWORK=mainnet
 HEIGHT=<height of the state you want to compute>
 STABILITY_THRESHOLD=<desired stability threshold>
 ```
 
 ## 3. Download the Dogecoin state
 
-Run `1_download_state.sh`, which downloads the dogecoin state. This can several hours.
+Run `1_download_state.sh`, which downloads the dogecoin state. This can take several hours.
 
 ```shell
 ./1_download_state.sh $DOGECOIN_DIR $NETWORK $HEIGHT

--- a/bootstrap/utils.sh
+++ b/bootstrap/utils.sh
@@ -52,7 +52,8 @@ generate_config() {
     # Basic configuration.
     cat << EOF > "$conf_file"
 # Reduce storage requirements by only storing the most recent N MiB of blocks.
-prune=5000
+# Dogecoin: we don't set the prune option as it also prunes AuxPow information.
+# prune=5000
 
 # Disable XOR-ing blocksdir *.dat files.
 # See "Blockstorage" section at https://bitcoincore.org/en/releases/28.0/


### PR DESCRIPTION
Enabling the prune option during bootstrap helps reduce the storage requirement when synchronizing the Dogecoin blockchain. However, it has the unintended effect of pruning the AuxPow information, which is needed by the canister. This PR disables the prune option. 

Note: the dogecoin-cli `getblockheader` command used to [get serialized headers](https://github.com/dfinity/dogecoin-canister/blob/master/bootstrap/3_compute_block_headers.sh) (with the false option), will return a null headers (all zeros) in case the header is a AuxPow header and has been pruned:
```
$ ./dogecoin-1.14.9/bin/dogecoin-cli -datadir="./data" getblockheader "6fc9305c6ae0362d2aa3716694d9500f6321b9932cfb39a1f6bcb72e6a90d33f" false
0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
```