### PR TITLE
feat(bootstrap): compute pure header only

### DIFF
--- a/bootstrap/3_compute_block_headers.sh
+++ b/bootstrap/3_compute_block_headers.sh
@@ -56,6 +56,14 @@ for ((height = 0; height <= STABLE_HEIGHT; height++)); do
     BLOCK_HEADER=$("$DOGECOIN_CLI" -conf="$CONF_FILE" -datadir="$DATA_DIR" getblockheader "$BLOCK_HASH" false)
     PURE_HEADER="${BLOCK_HEADER:0:160}"
 
+    # Check if header is all zeros (indicates missing data, e.g. pruned AuxPow header)
+    if [[ "$PURE_HEADER" =~ ^0+$ ]]; then
+        echo "Error: Got all zeros header at height $height (hash: $BLOCK_HASH)"
+        echo "This likely means that the header is a AuxPow header which has been pruned."
+        echo "Try syncing the chain again without the prune option."
+        exit 1
+    fi
+
     # Append the block hash and header to the file.
     echo "$BLOCK_HASH,$PURE_HEADER" >> "$BLOCK_HEADERS_FILE"
 

--- a/bootstrap/3_compute_block_headers.sh
+++ b/bootstrap/3_compute_block_headers.sh
@@ -54,9 +54,10 @@ echo "Fetching block headers up to height $STABLE_HEIGHT..."
 for ((height = 0; height <= STABLE_HEIGHT; height++)); do
     BLOCK_HASH=$("$DOGECOIN_CLI" -conf="$CONF_FILE" -datadir="$DATA_DIR" getblockhash "$height")
     BLOCK_HEADER=$("$DOGECOIN_CLI" -conf="$CONF_FILE" -datadir="$DATA_DIR" getblockheader "$BLOCK_HASH" false)
+    PURE_HEADER="${BLOCK_HEADER:0:160}"
 
     # Append the block hash and header to the file.
-    echo "$BLOCK_HASH,$BLOCK_HEADER" >> "$BLOCK_HEADERS_FILE"
+    echo "$BLOCK_HASH,$PURE_HEADER" >> "$BLOCK_HEADERS_FILE"
 
     # Calculate and log progress every 100 blocks.
     if ((height % 100 == 0 || height == STABLE_HEIGHT)); then

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -7,7 +7,7 @@ computed offline much more quickly with the help of `dogecoind`.
 
 * A linux machine
 * \>= 16GiB RAM
-* \>= 100GB of disk space
+* \>= 200GB of disk space
 
 ## 1. Download Dogecoin Core
 


### PR DESCRIPTION
When querying headers during the bootstrap process, only write pure header information (first 80-byte) into the block headers file. This is because the stable memory of the canister only stores pure header information (no AuxPow info).