### PR TITLE
fix: invalidateblock dogecoin-cli command crashing

### DIFF
--- a/bootstrap/1_download_state.sh
+++ b/bootstrap/1_download_state.sh
@@ -78,7 +78,3 @@ BLOCK_HASH=$("$DOGECOIN_CLI" -conf="$CONF_FILE" -datadir="$DATA_DIR" getblockhas
 # Wait for daemon to exit cleanly
 wait $DOGECOIN_PID
 
-# Create a backup of the downloaded data.
-echo "Creating a backup of the downloaded state in: $BACKUP_DIR"
-cp -r "$DATA_DIR" "$BACKUP_DIR"
-echo "Backup complete."

--- a/bootstrap/1_download_state.sh
+++ b/bootstrap/1_download_state.sh
@@ -73,15 +73,6 @@ done
 BLOCK_HASH=$("$DOGECOIN_CLI" -conf="$CONF_FILE" -datadir="$DATA_DIR" getblockhash "$((HEIGHT_STOP_SYNC + 1))")
 "$DOGECOIN_CLI" -conf="$CONF_FILE" -datadir="$DATA_DIR" invalidateblock "$BLOCK_HASH"
 
-COUNT=$("$DOGECOIN_CLI" -conf="$CONF_FILE" -datadir="$DATA_DIR" getblockcount)
-
-# We need at least two blocks beyond the target height (unstable blocks).
-if [[ "$COUNT" -le "$((HEIGHT + 1))" ]]; then
-    echo "Error: Blocks not fully synchronized. Current height: $COUNT. Additional unstable blocks beyond $HEIGHT are needed. Stopping node..." >&2
-else
-    echo "Blocks synchronized successfully. Current height: $COUNT. Stopping node..."
-fi
-
 "$DOGECOIN_CLI" -conf="$CONF_FILE" -datadir="$DATA_DIR" stop
 
 # Wait for daemon to exit cleanly


### PR DESCRIPTION
This PR:
- removes calling `getblockcount` after calling `invalidateblock`. An alternative could be to wait for the daemon to finish invalidating block cleanly. However, computing the block count is actually not necessary (users should verify themselves that the chain was fully synced) and the easy way is to simply to remove it.
- removes backing up the data. Since Dogecoin is not run in prune mode, the disk space requirement is quite high and we cannot afford having the data copied and backed up.  