### PR TITLE
refactor: de-generify `GenericState` and `GenericUnstableBlocks`

### DIFF
--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -186,22 +186,6 @@ pub struct BlockTree<Block> {
     children: Vec<BlockTree<Block>>,
 }
 
-impl<A> BlockTree<A> {
-    pub fn map<B, F: Fn(A) -> B>(self, f: &F) -> BlockTree<B> {
-        BlockTree {
-            root: f(self.root),
-            children: self.children.into_iter().map(|t| t.map(f)).collect(),
-        }
-    }
-}
-
-impl BlockTree<Block> {
-    pub fn into_cached<C: BlocksCache + 'static>(self, cache: C) -> BlockTree<CachedBlock> {
-        let cache: Cache = Rc::new(RefCell::new(Box::new(cache)));
-        self.map(&|block| CachedBlock::new_cached(cache.clone(), block))
-    }
-}
-
 /// CachedBlock specific implementation
 impl BlockTree<CachedBlock> {
     /// Creates a new `BlockTree` with the given block as its root.
@@ -993,33 +977,6 @@ mod test {
         ciborium::ser::into_writer(&tree, &mut bytes).unwrap();
         let new_tree: BlockTree = ciborium::de::from_reader(&bytes[..]).unwrap();
         assert_eq!(tree, new_tree);
-    }
-
-    #[proptest]
-    fn serialize_deserialize_old_block_vs_cached_block(tree: BlockTree) {
-        let mut tree_bytes = vec![];
-        ciborium::ser::into_writer(&tree, &mut tree_bytes).unwrap();
-        let old_cache = tree.cache().clone();
-
-        // Create a BlockTree<Block> and test its serialization
-        let tree_of_block = tree.map(&|cached_block| cached_block.block());
-        let mut bytes = vec![];
-        ciborium::ser::into_writer(&tree_of_block, &mut bytes).unwrap();
-        let tree_of_block_1: super::BlockTree<Block> =
-            ciborium::de::from_reader(&bytes[..]).unwrap();
-        assert_eq!(tree_of_block, tree_of_block_1);
-
-        // Map BlockTree<Block> into BlockTree<CachedBlock>
-        let new_cache = TestBlocksCache::new(old_cache.borrow().network());
-        let new_tree = tree_of_block_1.into_cached(new_cache);
-        let mut new_tree_bytes = vec![];
-        ciborium::ser::into_writer(&new_tree, &mut new_tree_bytes).unwrap();
-
-        assert_eq!(tree_bytes, new_tree_bytes);
-        assert_eq!(
-            old_cache.borrow().collect(),
-            new_tree.cache().borrow().collect()
-        );
     }
 
     #[proptest]

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -237,10 +237,6 @@ impl<Block> BlockTree<Block> {
         }
     }
 
-    pub fn into_root(self) -> Block {
-        self.root
-    }
-
     pub fn root(&self) -> &Block {
         &self.root
     }

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -764,9 +764,7 @@ mod test {
     }
 
     #[test]
-
-    #[test]
-    fn test_post_upgrade_state_conversion() {
+    fn test_post_upgrade_state_roundtrip() {
         memory::set_memory(ic_stable_structures::DefaultMemoryImpl::default());
         let network = Network::Regtest;
         init(InitConfig {
@@ -786,29 +784,20 @@ mod test {
             });
         }
 
-        // Take out the state (which also clears the `STATE` singleton).
-        // The state here explicitly uses BlockTree<Block> instead of BlockTree<CachedBlock>.
-        let old_state: state::GenericState<blocktree::BlockTree<Block>> = STATE
-            .with(|cell| cell.take().unwrap())
-            .map_tree(|tree| tree.map(&|block: blocktree::CachedBlock| block.block()));
-
-        // Serialize the state to bytes
+        // Take out the state and serialize it.
+        let old_state = STATE.with(|cell| cell.take().unwrap());
         let mut state_bytes = vec![];
         ciborium::ser::into_writer(&old_state, &mut state_bytes).unwrap();
 
-        // Write state (of BlockTree<Block>) into stable memory
+        // Write state into stable memory
         let memory = memory::get_upgrades_memory();
         memory::write(&memory, 0, &state_bytes);
 
-        // Run postupgrade hook
+        // Run post_upgrade hook
         post_upgrade(None);
 
-        // The state after going through proper post_upgrade handling is using
-        // BlockTree<CachedBlock> internally. To assert equivalence to old_state
-        // we need to convert it to the same type as the old state.
-        let new_state = STATE
-            .with(|cell| cell.take().unwrap())
-            .map_tree(|tree| tree.map(&|block: blocktree::CachedBlock| block.block()));
+        // Verify the round-tripped state is equivalent.
+        let new_state = STATE.with(|cell| cell.take().unwrap());
         assert!(new_state == old_state);
     }
 }

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -37,7 +37,6 @@ use ic_doge_interface::{
 use ic_doge_types::Block;
 use ic_stable_structures::reader::{BufferedReader, Reader};
 use ic_stable_structures::writer::{BufferedWriter, Writer};
-use ic_stable_structures::Memory;
 pub use memory::get_memory;
 use serde_bytes::ByteBuf;
 use state::main_chain_height;
@@ -45,9 +44,6 @@ use std::convert::TryInto;
 use std::io::Write;
 use std::{cell::RefCell, cmp::max};
 use utxo_set::UtxoSet;
-
-/// WASM page size is 64KB
-const WASM_PAGE_SIZE: u64 = 1 << 15;
 
 /// The maximum number of blocks the canister can be behind the tip to be considered synced.
 const SYNCED_THRESHOLD: u32 = 2;
@@ -223,15 +219,17 @@ pub fn post_upgrade(config_update: Option<SetConfigRequest>) {
 
     let reader = Reader::new(&memory, 0);
     let mut buffered_reader = BufferedReader::new(BUFFER_SIZE, reader);
-    let state = ciborium::de::from_reader(&mut buffered_reader).map(|mut state: State| {
-        let cache = unstable_blocks::BlocksCacheInStableMem::new(
-            state.network(),
-            memory::get_unstable_blocks_memory(),
-        );
-        // Reset cache to stable memory
-        state.replace_unstable_blocks_cache(cache);
-        state
-    }).expect("Failed to read state.");
+    let state = ciborium::de::from_reader(&mut buffered_reader)
+        .map(|mut state: State| {
+            let cache = unstable_blocks::BlocksCacheInStableMem::new(
+                state.network(),
+                memory::get_unstable_blocks_memory(),
+            );
+            // Reset cache to stable memory
+            state.replace_unstable_blocks_cache(cache);
+            state
+        })
+        .expect("Failed to read state.");
 
     set_state(state);
 

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -221,86 +221,17 @@ pub fn post_upgrade(config_update: Option<SetConfigRequest>) {
 
     let memory = memory::get_upgrades_memory();
 
-    let state: State = {
-        // Buffered reader at offset 0
-        let read_buffer_offset_0 = || {
-            let reader = Reader::new(&memory, 0);
-            let mut buffered_reader = BufferedReader::new(BUFFER_SIZE, reader);
-            ciborium::de::from_reader(&mut buffered_reader)
-        };
-
-        // Read Old State type
-        let read_buffer_offset_0_old_state = || {
-            let reader = Reader::new(&memory, 0);
-            let mut buffered_reader = BufferedReader::new(BUFFER_SIZE, reader);
-            ciborium::de::from_reader(&mut buffered_reader).map(
-                |state: state::GenericState<blocktree::BlockTree<Block>>| {
-                    let cache = unstable_blocks::BlocksCacheInStableMem::new(
-                        state.network(),
-                        memory::get_unstable_blocks_memory(),
-                    );
-                    state.map_tree(|tree| tree.into_cached(cache))
-                },
-            )
-        };
-
-        // Buffered reader at offset 4
-        let read_buffer_offset_4 = || {
-            let reader = Reader::new(&memory, 4);
-            let mut buffered_reader = BufferedReader::new(BUFFER_SIZE, reader);
-            ciborium::de::from_reader(&mut buffered_reader)
-        };
-
-        // Read into array
-        let read_array = || {
-            let mut state_len_bytes = [0; 4];
-            memory.read(0, &mut state_len_bytes);
-            let state_len = u32::from_le_bytes(state_len_bytes) as usize;
-            if state_len as u64 + 4 > memory.size() * WASM_PAGE_SIZE {
-                return Err(ciborium::de::Error::Semantic(
-                    None,
-                    "Out of bounds".to_string(),
-                ));
-            }
-            let mut state_bytes = vec![0; state_len];
-            memory.read(4, &mut state_bytes);
-
-            ciborium::de::from_reader(&*state_bytes)
-        };
-
-        read_buffer_offset_0()
-            .or_else(|e| {
-                print(&format!(
-                    "Failed to read state with buffered reader: {:?}. Trying different format...",
-                    e
-                ));
-                read_buffer_offset_4()
-            })
-            .or_else(|e| {
-                print(&format!(
-                    "Failed to read state with buffered reader at offset 4: {:?}. Trying different format...",
-                    e
-                ));
-                read_array()
-            })
-            .map(|mut state: State| {
-                let cache = unstable_blocks::BlocksCacheInStableMem::new(
-                    state.network(),
-                    memory::get_unstable_blocks_memory(),
-                );
-                // Reset cache to stable memory
-                state.replace_unstable_blocks_cache(cache);
-                state
-            })
-            .or_else(|e| {
-                print(&format!(
-                    "Failed to read state with buffered reader: {:?}. Trying different format...",
-                    e
-                ));
-                read_buffer_offset_0_old_state()
-            })
-            .expect("Failed to read state into array.")
-    };
+    let reader = Reader::new(&memory, 0);
+    let mut buffered_reader = BufferedReader::new(BUFFER_SIZE, reader);
+    let state = ciborium::de::from_reader(&mut buffered_reader).map(|mut state: State| {
+        let cache = unstable_blocks::BlocksCacheInStableMem::new(
+            state.network(),
+            memory::get_unstable_blocks_memory(),
+        );
+        // Reset cache to stable memory
+        state.replace_unstable_blocks_cache(cache);
+        state
+    }).expect("Failed to read state.");
 
     set_state(state);
 
@@ -833,34 +764,6 @@ mod test {
     }
 
     #[test]
-    fn test_post_upgrade_old_format_compatibility() {
-        memory::set_memory(ic_stable_structures::DefaultMemoryImpl::default());
-
-        init(InitConfig {
-            stability_threshold: Some(360),
-            network: Some(Network::Regtest),
-            ..Default::default()
-        });
-
-        // Take out the state (which also clears the `STATE` singleton).
-        let previous_state = STATE.with(|cell| cell.take().unwrap());
-
-        // Serialize the state to bytes
-        let mut state_bytes = vec![];
-        ciborium::ser::into_writer(&previous_state, &mut state_bytes).unwrap();
-
-        // Write state into stable memory using old format
-        let len = state_bytes.len() as u32;
-        let memory = memory::get_upgrades_memory();
-        memory::write(&memory, 0, &len.to_le_bytes());
-        memory::write(&memory, 4, &state_bytes);
-
-        // Run postupgrade hook
-        post_upgrade(None);
-
-        // The new and old states should be equivalent
-        with_state(|new_state| assert!(new_state == &previous_state));
-    }
 
     #[test]
     fn test_post_upgrade_state_conversion() {

--- a/canister/src/main.rs
+++ b/canister/src/main.rs
@@ -61,7 +61,6 @@ async fn heartbeat() {
     ic_doge_canister::heartbeat().await
 }
 
-// TODO: change to Koinu or Amount?
 #[update(manual_reply = true)]
 pub fn dogecoin_get_balance(request: GetBalanceRequest) -> PhantomData<Amount> {
     match ic_doge_canister::get_balance(request) {

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -2,14 +2,14 @@ use crate::validation::ValidationContextError;
 use crate::{
     address_utxoset::AddressUtxoSet,
     block_header_store::BlockHeaderStore,
-    blocktree::{BlockTree, CachedBlock, ChainBlock},
+    blocktree::ChainBlock,
     metrics::Metrics,
     runtime::{duration_since_epoch, inc_performance_counter, performance_counter, print},
     types::{
         into_dogecoin_network, Address, BlockHeaderBlob, GetSuccessorsCompleteResponse,
         GetSuccessorsPartialResponse, Slicing,
     },
-    unstable_blocks::{self, BlocksCache, GenericUnstableBlocks, UnstableBlocks},
+    unstable_blocks::{self, BlocksCache, UnstableBlocks},
     validation::ValidationContext,
     UtxoSet,
 };
@@ -27,12 +27,12 @@ use serde::{Deserialize, Serialize};
 // expensive in production.
 #[derive(Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
-pub struct GenericState<Tree> {
+pub struct State {
     /// The UTXOs of all stable blocks since genesis.
     pub utxos: UtxoSet,
 
     /// Blocks inserted, but are not considered stable yet.
-    pub unstable_blocks: GenericUnstableBlocks<Tree>,
+    pub unstable_blocks: UnstableBlocks,
 
     /// State used for syncing new blocks.
     pub syncing_state: SyncingState,
@@ -75,8 +75,6 @@ pub struct GenericState<Tree> {
     #[serde(default)]
     pub lazily_evaluate_fee_percentiles: Flag,
 }
-
-pub type State = GenericState<BlockTree<CachedBlock>>;
 
 impl State {
     /// Create a new blockchain.
@@ -124,9 +122,7 @@ impl State {
     pub fn replace_unstable_blocks_cache<Cache: BlocksCache + 'static>(&mut self, cache: Cache) {
         self.unstable_blocks.replace_blocks_cache(cache)
     }
-}
 
-impl<A> GenericState<A> {
     pub fn network(&self) -> Network {
         self.utxos.network()
     }
@@ -134,40 +130,6 @@ impl<A> GenericState<A> {
     /// The height of the latest stable block.
     pub fn stable_height(&self) -> Height {
         self.utxos.next_height()
-    }
-
-    /// Mapping the tree type in unstable blocks to a different type.
-    pub fn map_tree<B, F: FnOnce(A) -> B>(self, f: F) -> GenericState<B> {
-        let GenericState {
-            utxos,
-            unstable_blocks,
-            syncing_state,
-            blocks_source,
-            fee_percentiles_cache,
-            stable_block_headers,
-            fees,
-            metrics,
-            api_access,
-            disable_api_if_not_fully_synced,
-            watchdog_canister,
-            burn_cycles,
-            lazily_evaluate_fee_percentiles,
-        } = self;
-        GenericState {
-            utxos,
-            unstable_blocks: unstable_blocks.map_tree(f),
-            syncing_state,
-            blocks_source,
-            fee_percentiles_cache,
-            stable_block_headers,
-            fees,
-            metrics,
-            api_access,
-            disable_api_if_not_fully_synced,
-            watchdog_canister,
-            burn_cycles,
-            lazily_evaluate_fee_percentiles,
-        }
     }
 }
 

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -66,35 +66,14 @@ pub fn testnet_unstable_max_depth_difference(
 ///   depth(block) ≥ stability_threshold
 ///   ∀ b', height(b') = height(b): depth(b) - depth(b’) ≥ stability_threshold
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
-pub struct GenericUnstableBlocks<Tree> {
+pub struct UnstableBlocks {
     stability_threshold: u32,
-    tree: Tree,
+    tree: BlockTree<CachedBlock>,
     outpoints_cache: OutPointsCache,
     network: Network,
     // The headers of the blocks that are expected to be received.
     next_block_headers: NextBlockHeaders,
 }
-
-impl<A> GenericUnstableBlocks<A> {
-    pub fn map_tree<B, F: FnOnce(A) -> B>(self, f: F) -> GenericUnstableBlocks<B> {
-        let GenericUnstableBlocks {
-            stability_threshold,
-            tree,
-            outpoints_cache,
-            network,
-            next_block_headers,
-        } = self;
-        GenericUnstableBlocks {
-            stability_threshold,
-            tree: f(tree),
-            outpoints_cache,
-            network,
-            next_block_headers,
-        }
-    }
-}
-
-pub type UnstableBlocks = GenericUnstableBlocks<BlockTree<CachedBlock>>;
 
 impl UnstableBlocks {
     pub fn new<Cache: blocks_cache::BlocksCache + 'static>(


### PR DESCRIPTION
[DEFI-2719](https://dfinity.atlassian.net/browse/DEFI-2719): Since the Dogecoin canister has [now](https://dashboard.internetcomputer.org/proposal/139499) been migrated to caching unstable blocks in stable memory, the corresponding migration path can be removed. This PR is the first of a series. It replaces `GenericState` containing `GenericUnstableBlocks<Tree>` with `State` containing `UnstableBlocks`. The next PR will take care of de-generifying `BlockTree<Block>`.

Additionally, it also removes the migration path for reading the state serialized using an array to using a buffered reader during `post_upgrade`. 

[DEFI-2719]: https://dfinity.atlassian.net/browse/DEFI-2719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ