### PR TITLE
refactor: de-generify `BlockTree<Block>`

### DIFF
--- a/benchmarks/auxpow/canbench_results.yml
+++ b/benchmarks/auxpow/canbench_results.yml
@@ -2,14 +2,14 @@ benches:
   insert_block_headers_multiple_times_regtest_with_auxpow:
     total:
       calls: 1
-      instructions: 3529390008
+      instructions: 3529382468
       heap_increase: 6
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers_regtest_with_auxpow:
     total:
       calls: 1
-      instructions: 3485367556
+      instructions: 3485359767
       heap_increase: 3
       stable_memory_increase: 0
     scopes: {}

--- a/benchmarks/legacy/canbench_results.yml
+++ b/benchmarks/legacy/canbench_results.yml
@@ -2,41 +2,41 @@ benches:
   get_blockchain_info_many_branches:
     total:
       calls: 1
-      instructions: 25318517
+      instructions: 25316889
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_single_chain:
     total:
       calls: 1
-      instructions: 50198830
+      instructions: 50196830
       heap_increase: 5
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_with_forks:
     total:
       calls: 1
-      instructions: 50699276
+      instructions: 50697206
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   get_metrics:
     total:
       calls: 1
-      instructions: 3446166
+      instructions: 3354932
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   insert_300_blocks:
     total:
       calls: 1
-      instructions: 4130840527
+      instructions: 4130823788
       heap_increase: 9
       stable_memory_increase: 0
     scopes:
       validate:
         calls: 300
-        instructions: 4069166835
+        instructions: 4069166814
         heap_increase: 9
         stable_memory_increase: 0
       validate_block:
@@ -57,35 +57,35 @@ benches:
   insert_block_headers:
     total:
       calls: 1
-      instructions: 1424266681
+      instructions: 1424266754
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers_multiple_times:
     total:
       calls: 1
-      instructions: 13373426876
+      instructions: 13373419402
       heap_increase: 9
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers_multiple_times_regtest_without_auxpow:
     total:
       calls: 1
-      instructions: 3483373311
+      instructions: 3483365767
       heap_increase: 3
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers_regtest_without_auxpow:
     total:
       calls: 1
-      instructions: 3458483378
+      instructions: 3458475489
       heap_increase: 3
       stable_memory_increase: 0
     scopes: {}
   insert_block_with_10k_transactions:
     total:
       calls: 1
-      instructions: 2036548497
+      instructions: 2036548492
       heap_increase: 69
       stable_memory_increase: 0
     scopes:
@@ -112,7 +112,7 @@ benches:
   insert_block_with_1k_transactions:
     total:
       calls: 1
-      instructions: 195151112
+      instructions: 195151107
       heap_increase: 8
       stable_memory_increase: 0
     scopes:
@@ -139,7 +139,7 @@ benches:
   pre_upgrade_with_many_unstable_blocks:
     total:
       calls: 1
-      instructions: 6889525095
+      instructions: 6910991643
       heap_increase: 0
       stable_memory_increase: 1024
     scopes:
@@ -150,7 +150,7 @@ benches:
         stable_memory_increase: 0
       serialize_blocktree_serialize_seq:
         calls: 1
-        instructions: 67663907
+        instructions: 67537967
         heap_increase: 0
         stable_memory_increase: 0
 version: 0.4.0

--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -1,5 +1,5 @@
 use crate::{
-    blocktree::{CachedBlock, ChainBlock},
+    blocktree::CachedBlock,
     charge_cycles,
     runtime::{performance_counter, print},
     state::{FeePercentilesCache, State},

--- a/canister/src/api/get_balance.rs
+++ b/canister/src/api/get_balance.rs
@@ -1,5 +1,4 @@
 use crate::{
-    blocktree::ChainBlock,
     charge_cycles,
     runtime::{performance_counter, print},
     types::{Address, AddressParseError, GetBalanceRequest},

--- a/canister/src/api/get_utxos.rs
+++ b/canister/src/api/get_utxos.rs
@@ -1,5 +1,5 @@
 use crate::{
-    blocktree::{BlockChain, CachedBlock, ChainBlock},
+    blocktree::BlockChain,
     charge_cycles,
     runtime::{performance_counter, print},
     types::{Address, AddressParseError, GetUtxosRequest, Page, Utxo},
@@ -193,7 +193,7 @@ fn get_utxos_from_chain(
     state: &State,
     address: &str,
     min_confirmations: u32,
-    chain: BlockChain<CachedBlock>,
+    chain: BlockChain<'_>,
     offset: Option<Utxo>,
     utxo_limit: usize,
 ) -> Result<(GetUtxosResponse, Stats), GetUtxosError> {

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -43,36 +43,52 @@ impl CachedBlock {
     pub fn block(&self) -> Block {
         self.cache.borrow().get(&self.block_hash).unwrap()
     }
+
+    pub fn header(&self) -> &Header {
+        &self.header
+    }
+
+    pub fn block_hash(&self) -> &BlockHash {
+        &self.block_hash
+    }
+
+    pub fn prev_block_hash(&self) -> BlockHash {
+        BlockHash::from(self.header().prev_blockhash)
+    }
+
+    pub fn difficulty(&self) -> u128 {
+        self.difficulty
+    }
 }
 
 /// Represents a non-empty block chain as:
 /// * the first block of the chain
 /// * the successors to this block (which can be an empty list)
 #[derive(Debug, PartialEq, Eq)]
-pub struct BlockChain<'a, Block> {
+pub struct BlockChain<'a> {
     // The first block of this `BlockChain`, i.e. the one at the lowest height.
-    first: &'a Block,
+    first: &'a CachedBlock,
     // The successor blocks of this `BlockChain`, i.e. the chain after the
     // `first` block.
-    successors: Vec<&'a Block>,
+    successors: Vec<&'a CachedBlock>,
 }
 
-impl<'a, Block> BlockChain<'a, Block> {
+impl<'a> BlockChain<'a> {
     /// Creates a new `BlockChain` with the given `first` block and an empty list
     /// of successors.
-    pub fn new(first: &'a Block) -> Self {
+    pub fn new(first: &'a CachedBlock) -> Self {
         Self {
             first,
             successors: vec![],
         }
     }
 
-    pub fn new_with_successors(first: &'a Block, successors: Vec<&'a Block>) -> Self {
+    pub fn new_with_successors(first: &'a CachedBlock, successors: Vec<&'a CachedBlock>) -> Self {
         Self { first, successors }
     }
 
     /// Appends a new block to the list of `successors` of this `BlockChain`.
-    pub fn push(&mut self, block: &'a Block) {
+    pub fn push(&mut self, block: &'a CachedBlock) {
         self.successors.push(block);
     }
 
@@ -81,11 +97,11 @@ impl<'a, Block> BlockChain<'a, Block> {
         self.successors.len() + 1
     }
 
-    pub fn first(&self) -> &'a Block {
+    pub fn first(&self) -> &'a CachedBlock {
         self.first
     }
 
-    pub fn tip(&self) -> &'a Block {
+    pub fn tip(&self) -> &'a CachedBlock {
         match self.successors.last() {
             None => {
                 // The chain consists of only one block, and that is the tip.
@@ -96,27 +112,10 @@ impl<'a, Block> BlockChain<'a, Block> {
     }
 
     /// Consumes this `BlockChain` and returns the entire chain of blocks.
-    pub fn into_chain(self) -> Vec<&'a Block> {
+    pub fn into_chain(self) -> Vec<&'a CachedBlock> {
         let mut chain = vec![self.first];
         chain.extend(self.successors);
         chain
-    }
-
-    /// Return the Block at the given index in the chain if the index is in range.
-    /// Otherwise return None.
-    pub fn get(&self, index: usize) -> Option<&'a Block> {
-        if index == 0 {
-            Some(self.first)
-        } else if index - 1 < self.successors.len() {
-            Some(self.successors[index - 1])
-        } else {
-            None
-        }
-    }
-
-    /// Return an iterator of all blocks in the chain starting from the first one.
-    pub fn iter(&self) -> impl Iterator<Item = &'a Block> + '_ {
-        std::iter::once(self.first).chain(self.successors.iter().copied())
     }
 }
 
@@ -181,13 +180,13 @@ impl Sub for DifficultyBasedDepth {
 
 /// Maintains a tree of connected blocks.
 #[derive(Debug, PartialEq, Eq)]
-pub struct BlockTree<Block> {
-    root: Block,
-    children: Vec<BlockTree<Block>>,
+pub struct BlockTree {
+    root: CachedBlock,
+    children: Vec<BlockTree>,
 }
 
-/// CachedBlock specific implementation
-impl BlockTree<CachedBlock> {
+/// Cache-specific methods
+impl BlockTree {
     /// Creates a new `BlockTree` with the given block as its root.
     pub fn new_with_cache<Cache: BlocksCache + 'static>(cache: Cache, root: Block) -> Self {
         Self::new_with_shared_cache(Rc::new(RefCell::new(Box::new(cache))), root)
@@ -228,16 +227,16 @@ impl BlockTree<CachedBlock> {
     }
 }
 
-impl<Block> BlockTree<Block> {
+impl BlockTree {
     /// Creates a new `BlockTree` with the given block as its root.
-    pub fn new(root: Block) -> Self {
+    pub fn new(root: CachedBlock) -> Self {
         Self {
             root,
             children: vec![],
         }
     }
 
-    pub fn root(&self) -> &Block {
+    pub fn root(&self) -> &CachedBlock {
         &self.root
     }
 
@@ -272,7 +271,7 @@ impl<Block> BlockTree<Block> {
             .collect()
     }
 
-    fn get_child_blocks(&self) -> Vec<&Block> {
+    fn get_child_blocks(&self) -> Vec<&CachedBlock> {
         self.children.iter().map(|c| &c.root).collect()
     }
 
@@ -295,44 +294,22 @@ impl<Block> BlockTree<Block> {
     }
 
     /// Returns all blocks in the tree.
-    pub fn blocks(&self) -> impl Iterator<Item = &Block> {
+    pub fn blocks(&self) -> impl Iterator<Item = &CachedBlock> {
         Box::new(
             std::iter::once(&self.root)
                 .chain(self.children.iter().flat_map(|child| child.blocks())),
-        ) as Box<dyn Iterator<Item = &Block>>
+        ) as Box<dyn Iterator<Item = &CachedBlock>>
     }
 }
 
-pub trait ChainBlock {
-    fn header(&self) -> &Header;
-    fn block_hash(&self) -> &BlockHash;
-    fn prev_block_hash(&self) -> BlockHash;
-    fn difficulty(&self) -> u128;
-}
-
-impl ChainBlock for CachedBlock {
-    fn header(&self) -> &Header {
-        &self.header
-    }
-    fn block_hash(&self) -> &BlockHash {
-        &self.block_hash
-    }
-    fn prev_block_hash(&self) -> BlockHash {
-        BlockHash::from(self.header().prev_blockhash)
-    }
-    fn difficulty(&self) -> u128 {
-        self.difficulty
-    }
-}
-
-impl<Block: ChainBlock> BlockTree<Block> {
+impl BlockTree {
     /// Extends the tree with the given block.
     ///
     /// Blocks can extend the tree in the following cases:
     ///   * The block is a successor of a block already in the tree.
     ///
     /// Note that `ValidationContext` ensures that the block to insert is not already present.
-    pub fn extend(&mut self, block: Block) -> Result<(), BlockDoesNotExtendTree> {
+    pub fn extend(&mut self, block: CachedBlock) -> Result<(), BlockDoesNotExtendTree> {
         debug_assert!(
             self.find(block.block_hash()).is_none(),
             "BUG: block {} is already present in the tree, but this should have been prevented when instantiating `ValidationContext`",
@@ -359,7 +336,7 @@ impl<Block: ChainBlock> BlockTree<Block> {
     pub fn get_chain_with_tip<'a>(
         &'a self,
         tip: &BlockHash,
-    ) -> Option<(BlockChain<'a, Block>, Vec<&'a Block>)> {
+    ) -> Option<(BlockChain<'a>, Vec<&'a CachedBlock>)> {
         // Compute the chain in reverse order, as that's more efficient, and then
         // reverse it to get the answer in the correct order.
         self.get_chain_with_tip_reverse(tip)
@@ -383,10 +360,10 @@ impl<Block: ChainBlock> BlockTree<Block> {
     // Do a depth-first search to find the blockchain that ends with the given `tip`.
     // For performance reasons, the list is returned in the reverse order, starting
     // from `tip` and ending with `anchor`.
-    fn get_chain_with_tip_reverse<'a>(
-        &'a self,
+    fn get_chain_with_tip_reverse(
+        &self,
         tip: &BlockHash,
-    ) -> Option<(Vec<&'a Block>, Vec<&'a Block>)> {
+    ) -> Option<(Vec<&CachedBlock>, Vec<&CachedBlock>)> {
         if self.root.block_hash() == tip {
             return Some((vec![&self.root], self.get_child_blocks()));
         }
@@ -419,7 +396,7 @@ impl<Block: ChainBlock> BlockTree<Block> {
     /// criteria, the chain ends at this node (contested tip).
     ///
     /// Runs in O(n) time where n is the number of blocks in the tree.
-    pub fn main_chain_by_difficulty(&self) -> BlockChain<'_, Block> {
+    pub fn main_chain_by_difficulty(&self) -> BlockChain<'_> {
         let (_, _, mut chain_rev) = self.main_chain_by_difficulty_inner();
         let first = chain_rev
             .pop()
@@ -429,7 +406,7 @@ impl<Block: ChainBlock> BlockTree<Block> {
     }
 
     /// Bottom-up DFS returning (accumulated_difficulty, depth, main_chain_reversed).
-    fn main_chain_by_difficulty_inner(&self) -> (DifficultyBasedDepth, usize, Vec<&Block>) {
+    fn main_chain_by_difficulty_inner(&self) -> (DifficultyBasedDepth, usize, Vec<&CachedBlock>) {
         let self_difficulty = DifficultyBasedDepth::new(self.root.difficulty());
 
         if self.children.is_empty() {
@@ -437,7 +414,7 @@ impl<Block: ChainBlock> BlockTree<Block> {
         }
 
         let mut best_key = (DifficultyBasedDepth::new(0), 0usize);
-        let mut best_chain: Vec<&Block> = vec![];
+        let mut best_chain: Vec<&CachedBlock> = vec![];
         let mut contested = false;
 
         for child in self.children.iter() {
@@ -521,15 +498,12 @@ impl<Block: ChainBlock> BlockTree<Block> {
 
     /// Returns a `BlockTree` where the hash of the root block matches the provided `block_hash`
     /// along with its depth if it exists, and `None` otherwise.
-    pub fn find_mut<'a>(
-        &'a mut self,
-        blockhash: &BlockHash,
-    ) -> Option<(&'a mut BlockTree<Block>, u32)> {
-        fn find_mut_helper<'a, Block: ChainBlock>(
-            block_tree: &'a mut BlockTree<Block>,
+    pub fn find_mut(&mut self, blockhash: &BlockHash) -> Option<(&mut BlockTree, u32)> {
+        fn find_mut_helper<'a>(
+            block_tree: &'a mut BlockTree,
             blockhash: &BlockHash,
             depth: u32,
-        ) -> Option<(&'a mut BlockTree<Block>, u32)> {
+        ) -> Option<(&'a mut BlockTree, u32)> {
             if block_tree.root.block_hash() == blockhash {
                 return Some((block_tree, depth));
             }
@@ -548,7 +522,7 @@ impl<Block: ChainBlock> BlockTree<Block> {
 
     /// Returns a `BlockTree` where the hash of the root matches the hash of the provided `block`
     /// if it exists, and `None` otherwise.
-    fn find(&self, block_hash: &BlockHash) -> Option<&BlockTree<Block>> {
+    fn find(&self, block_hash: &BlockHash) -> Option<&BlockTree> {
         if self.root.block_hash() == block_hash {
             return Some(self);
         }
@@ -620,14 +594,14 @@ mod test {
     use std::collections::BTreeSet;
     use test_strategy::proptest;
 
-    type BlockTree = super::BlockTree<CachedBlock>;
+    type BlockTree = super::BlockTree;
 
     fn test_tree(root: Block) -> BlockTree {
         let cache = TestBlocksCache::new(Network::Mainnet);
         BlockTree::new_with_cache(cache, root)
     }
 
-    fn to_blockchain<'a, T>(blocks: &[&'a T]) -> BlockChain<'a, T> {
+    fn to_blockchain<'a>(blocks: &[&'a CachedBlock]) -> BlockChain<'a> {
         let mut iter = blocks.iter();
         BlockChain {
             first: iter.next().unwrap(),

--- a/canister/src/blocktree/serde.rs
+++ b/canister/src/blocktree/serde.rs
@@ -122,7 +122,7 @@ impl<'de> Visitor<'de> for CachedBlockTreeVisitor {
 /// The deserialization of a BlockTree would construct all CachedBlock
 /// using a dummy cache. This is a hack because it is difficult to pass an existing
 /// cache into the deserialization process, especially when the BlockTree is
-/// serveral levels down in a nested struct that derives Deserialize. The caller
+/// several levels down in a nested struct that derives Deserialize. The caller
 /// is expected to manually replace the dummy cache with the real cache after
 /// deserialization, otherwise any call into the dummy cache will panic.
 impl<'de> Deserialize<'de> for BlockTree {

--- a/canister/src/blocktree/serde.rs
+++ b/canister/src/blocktree/serde.rs
@@ -1,6 +1,5 @@
 use super::{Block, BlockHash, BlockTree, BlocksCache, CachedBlock};
 use bitcoin::block::Header;
-use bitcoin::dogecoin::Block as DogecoinBlock;
 use ic_doge_interface::Network;
 use serde::{
     de::{Deserializer, Error, SeqAccess, Visitor},
@@ -16,7 +15,7 @@ use std::rc::Rc;
 struct FlattenedTree<T>(Vec<(T, usize)>);
 
 impl<T> FlattenedTree<T> {
-    fn map_from<'a, A>(&mut self, tree: &'a BlockTree<A>, f: &(impl Fn(&'a A) -> T + 'a)) {
+    fn map_from<'a>(&mut self, tree: &'a BlockTree, f: &(impl Fn(&'a CachedBlock) -> T + 'a)) {
         self.0.push((f(&tree.root), tree.children.len()));
         for child in &tree.children {
             self.map_from(child, f)
@@ -35,29 +34,12 @@ impl<T: Serialize> Serialize for FlattenedTree<T> {
     }
 }
 
-/// Serialize `BlockTree<Block>` by flattening it into a list of `Block`.
-impl Serialize for BlockTree<Block> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut flattened = FlattenedTree(vec![]);
-        {
-            #[cfg(feature = "canbench-rs")]
-            let _p = canbench_rs::bench_scope("serialize_blocktree_flatten");
-            flattened.map_from(self, &|block| block.internal_bitcoin_block());
-        }
-        {
-            #[cfg(feature = "canbench-rs")]
-            let _p = canbench_rs::bench_scope("serialize_blocktree_serialize_seq");
-            flattened.serialize(serializer)
-        }
-    }
-}
-
-/// Serialize `BlockTree<CachedBlock>` by flattening it into a list of
+/// Serialize `BlockTree` by flattening it into a list of
 /// `(Header, BlockHash, Difficulty)` pairs.
 ///
 /// Note that the actual block is not serialized here because they are
 /// stored separately in a BlocksCache.
-impl Serialize for BlockTree<CachedBlock> {
+impl Serialize for BlockTree {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut flattened = FlattenedTree(vec![]);
         {
@@ -75,19 +57,39 @@ impl Serialize for BlockTree<CachedBlock> {
     }
 }
 
-/// Deserialization helper has to be a trait because different `BlockTree` requires
-/// different visitor type.
-trait TreeVisitor<'de, T>: Sized {
-    // Each instance must implement its own `next` function.
-    fn next<A: SeqAccess<'de>>(&self, seq: &mut A) -> Result<(T, usize), A::Error>;
+/// Visitor for `BlockTree`
+struct CachedBlockTreeVisitor(Rc<RefCell<Box<dyn BlocksCache>>>);
 
-    // Common routine that helps implementing [Deserialize::visit_seq].
-    fn visit_sequence<A: SeqAccess<'de>>(self, mut seq: A) -> Result<BlockTree<T>, A::Error> {
+impl<'de> Visitor<'de> for CachedBlockTreeVisitor {
+    type Value = BlockTree;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("A blocktree deserializer.")
+    }
+
+    fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+        fn next<'de, A: SeqAccess<'de>>(
+            seq: &mut A,
+            cache: &Rc<RefCell<Box<dyn BlocksCache>>>,
+        ) -> Result<(CachedBlock, usize), A::Error> {
+            seq.next_element::<((Header, BlockHash, u128), usize)>()?
+                .map(|((header, block_hash, difficulty), size)| {
+                    let block = CachedBlock {
+                        cache: cache.clone(),
+                        block_hash,
+                        difficulty,
+                        header,
+                    };
+                    (block, size)
+                })
+                .ok_or(A::Error::custom("reading next element must succeed"))
+        }
+
         // A stack containing a `BlockTree` along with how many children remain to be added to it.
-        let mut stack: Vec<(BlockTree<T>, usize)> = Vec::new();
+        let mut stack: Vec<(BlockTree, usize)> = Vec::new();
 
         // Read the root and add it to the stack.
-        let (root, children_to_add) = self.next(&mut seq)?;
+        let (root, children_to_add) = next(&mut seq, &self.0)?;
         stack.push((BlockTree::new(root), children_to_add));
 
         while let Some((tree, children_to_add)) = stack.pop() {
@@ -98,7 +100,7 @@ trait TreeVisitor<'de, T>: Sized {
                     None => {
                         // There's no parent to this tree. Deserialization is complete.
                         // Assert that there's no more data to deserialize.
-                        assert!(self.next(&mut seq).is_err());
+                        assert!(next(&mut seq, &self.0).is_err());
                         return Ok(tree);
                     }
                 }
@@ -108,7 +110,7 @@ trait TreeVisitor<'de, T>: Sized {
                 stack.push((tree, children_to_add - 1));
 
                 // Add the child to the stack.
-                let (child, grand_children_to_add) = self.next(&mut seq)?;
+                let (child, grand_children_to_add) = next(&mut seq, &self.0)?;
                 stack.push((BlockTree::new(child), grand_children_to_add));
             }
         }
@@ -117,76 +119,13 @@ trait TreeVisitor<'de, T>: Sized {
     }
 }
 
-/// Visitor for `BlockTree<Block>`
-struct BlockTreeVisitor;
-
-impl<'de> TreeVisitor<'de, Block> for BlockTreeVisitor {
-    fn next<A: SeqAccess<'de>>(&self, seq: &mut A) -> Result<(Block, usize), A::Error> {
-        seq.next_element::<(DogecoinBlock, usize)>()?
-            .map(|(block, size)| (Block::new(block), size))
-            .ok_or(A::Error::custom("reading next element must succeed"))
-    }
-}
-
-impl<'de> Visitor<'de> for BlockTreeVisitor {
-    type Value = BlockTree<Block>;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("A blocktree deserializer.")
-    }
-
-    fn visit_seq<A: SeqAccess<'de>>(self, seq: A) -> Result<Self::Value, A::Error> {
-        self.visit_sequence(seq)
-    }
-}
-
-impl<'de> Deserialize<'de> for BlockTree<Block> {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_seq(BlockTreeVisitor)
-    }
-}
-
-/// Visitor for `BlockTree<CachedBlock>`
-struct CachedBlockTreeVisitor(Rc<RefCell<Box<dyn BlocksCache>>>);
-
-impl<'de> TreeVisitor<'de, CachedBlock> for CachedBlockTreeVisitor {
-    fn next<A: SeqAccess<'de>>(&self, seq: &mut A) -> Result<(CachedBlock, usize), A::Error> {
-        seq.next_element::<((Header, BlockHash, u128), usize)>()?
-            .map(|((header, block_hash, difficulty), size)| {
-                let block = CachedBlock {
-                    cache: self.0.clone(),
-                    block_hash,
-                    difficulty,
-                    header,
-                };
-                (block, size)
-            })
-            .ok_or(A::Error::custom("reading next element must succeed"))
-    }
-}
-
-impl<'de> Visitor<'de> for CachedBlockTreeVisitor {
-    type Value = BlockTree<CachedBlock>;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("A blocktree deserializer.")
-    }
-
-    fn visit_seq<A: SeqAccess<'de>>(self, seq: A) -> Result<Self::Value, A::Error> {
-        self.visit_sequence(seq)
-    }
-}
-
-/// The deserialization of a BlockTree<CachedBlock> would construct all CachedBlock
+/// The deserialization of a BlockTree would construct all CachedBlock
 /// using a dummy cache. This is a hack because it is difficult to pass an existing
 /// cache into the deserialization process, especially when the BlockTree is
 /// serveral levels down in a nested struct that derives Deserialize. The caller
 /// is expected to manually replace the dummy cache with the real cache after
 /// deserialization, otherwise any call into the dummy cache will panic.
-impl<'de> Deserialize<'de> for BlockTree<CachedBlock> {
+impl<'de> Deserialize<'de> for BlockTree {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -2,7 +2,6 @@ use crate::validation::ValidationContextError;
 use crate::{
     address_utxoset::AddressUtxoSet,
     block_header_store::BlockHeaderStore,
-    blocktree::ChainBlock,
     metrics::Metrics,
     runtime::{duration_since_epoch, inc_performance_counter, performance_counter, print},
     types::{

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -1,7 +1,6 @@
 use crate::{
     blocktree::{
-        BlockChain, BlockDoesNotExtendTree, BlockTree, CachedBlock, ChainBlock, Depth,
-        DifficultyBasedDepth,
+        BlockChain, BlockDoesNotExtendTree, BlockTree, CachedBlock, Depth, DifficultyBasedDepth,
     },
     runtime::print,
     types::{Address, TxOut},
@@ -68,7 +67,7 @@ pub fn testnet_unstable_max_depth_difference(
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct UnstableBlocks {
     stability_threshold: u32,
-    tree: BlockTree<CachedBlock>,
+    tree: BlockTree,
     outpoints_cache: OutPointsCache,
     network: Network,
     // The headers of the blocks that are expected to be received.
@@ -313,7 +312,7 @@ pub fn push(
 /// difficulties are tied, the longest branch (by block count) wins. If
 /// branches still tie on both criteria, the chain ends at the fork point
 /// (contested tip).
-pub fn get_main_chain(blocks: &UnstableBlocks) -> BlockChain<'_, CachedBlock> {
+pub fn get_main_chain(blocks: &UnstableBlocks) -> BlockChain<'_> {
     blocks.tree.main_chain_by_difficulty()
 }
 
@@ -337,7 +336,7 @@ pub fn blocks_count(blocks: &UnstableBlocks) -> usize {
 pub fn get_chain_with_tip<'a>(
     blocks: &'a UnstableBlocks,
     tip: &BlockHash,
-) -> Option<(BlockChain<'a, CachedBlock>, Vec<&'a CachedBlock>)> {
+) -> Option<(BlockChain<'a>, Vec<&'a CachedBlock>)> {
     blocks.tree.get_chain_with_tip(tip)
 }
 

--- a/canister/src/validation.rs
+++ b/canister/src/validation.rs
@@ -1,4 +1,4 @@
-use crate::{blocktree::ChainBlock, state::State, unstable_blocks};
+use crate::{state::State, unstable_blocks};
 use bitcoin::{block::Header, hashes::Hash};
 use ic_doge_types::BlockHash;
 use ic_doge_validation::HeaderStore;


### PR DESCRIPTION
[DEFI-2719](https://dfinity.atlassian.net/browse/DEFI-2719): Since the Dogecoin canister has [now](https://dashboard.internetcomputer.org/proposal/139499) been migrated to caching unstable blocks in stable memory, the corresponding migration path can be removed. This PR is the second and last of a series (see https://github.com/dfinity/dogecoin-canister/pull/106). It replaces `BlockTree<Block>` with `BlockTree`.

[DEFI-2719]: https://dfinity.atlassian.net/browse/DEFI-2719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ