### PR TITLE
chore(upstream): cherry-pick from dfinity/bitcoin-canister@master (949c2aa)

### DIFF
--- a/benchmarks/legacy/canbench_results.yml
+++ b/benchmarks/legacy/canbench_results.yml
@@ -37,15 +37,15 @@ benches:
   dogecoin_get_utxos_baseline:
     total:
       calls: 1
-      instructions: 12757982094
-      heap_increase: 1
+      instructions: 224212916
+      heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   dogecoin_get_utxos_stress:
     total:
       calls: 1
-      instructions: 880428638540
-      heap_increase: 395
+      instructions: 461449246892
+      heap_increase: 393
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_many_branches:

--- a/benchmarks/legacy/canbench_results.yml
+++ b/benchmarks/legacy/canbench_results.yml
@@ -2,139 +2,139 @@ benches:
   dogecoin_get_balance_baseline:
     total:
       calls: 1
-      instructions: 57148463
+      instructions: 57105161
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   dogecoin_get_balance_stress:
     total:
       calls: 1
-      instructions: 2339831170
+      instructions: 2339785916
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   dogecoin_get_block_headers_baseline:
     total:
       calls: 1
-      instructions: 1047740
+      instructions: 1047841
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   dogecoin_get_block_headers_stress:
     total:
       calls: 1
-      instructions: 2837866
+      instructions: 2838629
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   dogecoin_get_current_fee_percentiles:
     total:
       calls: 1
-      instructions: 30384910
+      instructions: 30559962
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   dogecoin_get_utxos_baseline:
     total:
       calls: 1
-      instructions: 12785941867
+      instructions: 12757982094
       heap_increase: 1
       stable_memory_increase: 0
     scopes: {}
   dogecoin_get_utxos_stress:
     total:
       calls: 1
-      instructions: 880531540513
+      instructions: 880428638540
       heap_increase: 395
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_many_branches:
     total:
       calls: 1
-      instructions: 4618537692
-      heap_increase: 3150
+      instructions: 2768156
+      heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_single_chain:
     total:
       calls: 1
-      instructions: 4521005210
-      heap_increase: 3224
+      instructions: 2200708
+      heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_blockchain_info_with_forks:
     total:
       calls: 1
-      instructions: 4594277306
-      heap_increase: 3166
+      instructions: 2242018
+      heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   get_metrics:
     total:
       calls: 1
-      instructions: 3402682
+      instructions: 3398772
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   insert_300_blocks:
     total:
       calls: 1
-      instructions: 4130829898
+      instructions: 4131594318
       heap_increase: 9
       stable_memory_increase: 0
     scopes:
       validate:
         calls: 300
-        instructions: 4069166814
+        instructions: 4069145418
         heap_increase: 9
         stable_memory_increase: 0
       validate_block:
         calls: 300
-        instructions: 14859170
+        instructions: 14848519
         heap_increase: 0
         stable_memory_increase: 0
       validate_block/check_merkle_root:
         calls: 300
-        instructions: 6373718
+        instructions: 6373732
         heap_increase: 0
         stable_memory_increase: 0
       validate_block/ensure_unique_transactions:
         calls: 300
-        instructions: 6651996
+        instructions: 6641188
         heap_increase: 0
         stable_memory_increase: 0
   insert_block_headers:
     total:
       calls: 1
-      instructions: 1424357054
+      instructions: 1424390350
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers_multiple_times:
     total:
       calls: 1
-      instructions: 13381072102
+      instructions: 13381072165
       heap_increase: 9
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers_multiple_times_regtest_without_auxpow:
     total:
       calls: 1
-      instructions: 3483943083
+      instructions: 3483950043
       heap_increase: 3
       stable_memory_increase: 0
     scopes: {}
   insert_block_headers_regtest_without_auxpow:
     total:
       calls: 1
-      instructions: 3459057489
+      instructions: 3459063019
       heap_increase: 3
       stable_memory_increase: 0
     scopes: {}
   insert_block_with_10k_transactions:
     total:
       calls: 1
-      instructions: 2036548498
+      instructions: 2036841104
       heap_increase: 69
       stable_memory_increase: 0
     scopes:
@@ -161,18 +161,18 @@ benches:
   insert_block_with_1k_transactions:
     total:
       calls: 1
-      instructions: 195151113
+      instructions: 195179284
       heap_increase: 8
       stable_memory_increase: 0
     scopes:
       validate:
         calls: 1
-        instructions: 28938417
+        instructions: 28938608
         heap_increase: 3
         stable_memory_increase: 0
       validate_block:
         calls: 1
-        instructions: 15521973
+        instructions: 15522167
         heap_increase: 0
         stable_memory_increase: 0
       validate_block/check_merkle_root:
@@ -182,24 +182,24 @@ benches:
         stable_memory_increase: 0
       validate_block/ensure_unique_transactions:
         calls: 1
-        instructions: 8160812
+        instructions: 8161006
         heap_increase: 0
         stable_memory_increase: 0
   pre_upgrade_with_many_unstable_blocks:
     total:
       calls: 1
-      instructions: 6931384886
+      instructions: 6954681926
       heap_increase: 0
       stable_memory_increase: 1024
     scopes:
       serialize_blocktree_flatten:
         calls: 1
-        instructions: 254046
+        instructions: 224788
         heap_increase: 0
         stable_memory_increase: 0
       serialize_blocktree_serialize_seq:
         calls: 1
-        instructions: 67537967
+        instructions: 67441967
         heap_increase: 0
         stable_memory_increase: 0
 version: 0.4.0

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -298,18 +298,18 @@ pub fn main_chain_height(state: &State) -> Height {
 pub fn blockchain_info(state: &State) -> crate::types::BlockchainInfo {
     let main_chain = unstable_blocks::get_main_chain(&state.unstable_blocks);
     let tip_block = main_chain.tip();
-    let chain = main_chain.into_chain();
-    let blocks: Vec<Block> = chain.iter().map(|cached| cached.block()).collect();
+
+    let mut utxos_length = state.utxos.utxos_len() as i64;
+    for block in main_chain.into_chain() {
+        utxos_length += state.unstable_blocks.get_net_utxo_delta(block.block_hash());
+    }
 
     crate::types::BlockchainInfo {
         height: main_chain_height(state),
         block_hash: tip_block.block_hash().to_vec(),
         timestamp: tip_block.header().time,
         difficulty: tip_block.difficulty(),
-        utxos_length: crate::utxo_set::count_utxos_in_blocks(
-            state.utxos.utxos_len(),
-            blocks.iter(),
-        ),
+        utxos_length: utxos_length.max(0) as u64,
     }
 }
 

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -119,6 +119,11 @@ impl UnstableBlocks {
             .get_removed_outpoints(block_hash, address)
     }
 
+    /// Returns the net UTXO count change for the given block (added - removed).
+    pub fn get_net_utxo_delta(&self, block_hash: &BlockHash) -> i64 {
+        self.outpoints_cache.get_net_utxo_delta(block_hash)
+    }
+
     pub fn stability_threshold(&self) -> u32 {
         self.stability_threshold
     }

--- a/canister/src/unstable_blocks/outpoints_cache.rs
+++ b/canister/src/unstable_blocks/outpoints_cache.rs
@@ -18,6 +18,10 @@ pub struct OutPointsCache {
 
     /// Caches the outpoints removed for each address in a block.
     removed_outpoints: BTreeMap<BlockHash, BTreeMap<Address, Vec<OutPoint>>>,
+
+    /// Caches the net UTXO count change per block (outputs created - inputs spent).
+    #[serde(default)]
+    utxo_deltas: BTreeMap<BlockHash, i64>,
 }
 
 impl OutPointsCache {
@@ -26,6 +30,7 @@ impl OutPointsCache {
             tx_outs: BTreeMap::new(),
             added_outpoints: BTreeMap::new(),
             removed_outpoints: BTreeMap::new(),
+            utxo_deltas: BTreeMap::new(),
         }
     }
 
@@ -55,6 +60,11 @@ impl OutPointsCache {
             .unwrap_or(&[])
     }
 
+    /// Returns the net UTXO count change for the given block (outputs created - inputs spent).
+    pub fn get_net_utxo_delta(&self, block_hash: &BlockHash) -> i64 {
+        self.utxo_deltas.get(block_hash).copied().unwrap_or(0)
+    }
+
     /// Retrieves the `TxOut` associated with the given `outpoint`, along with its height.
     pub fn get_tx_out(&self, outpoint: &OutPoint) -> Option<(&TxOut, Height)> {
         self.tx_outs
@@ -73,6 +83,7 @@ impl OutPointsCache {
         let mut tx_outs: BTreeMap<OutPoint, TxOutInfo> = BTreeMap::new();
         let mut removed_outpoints = BTreeMap::new();
         let mut added_outpoints = BTreeMap::new();
+        let mut utxo_delta: i64 = 0;
 
         // The inputs of a transaction contain outpoints that reference the previous
         // outputs that it is consuming. These outputs can be retrieved from a number
@@ -86,6 +97,11 @@ impl OutPointsCache {
         //    The assumption here is that this cache already contains all the outpoints
         //    referenced by the unstable blocks.
         for tx in block.txdata() {
+            utxo_delta += tx.output().len() as i64;
+            if !tx.is_coinbase() {
+                utxo_delta -= tx.input().len() as i64;
+            }
+
             for input in tx.input() {
                 if input.previous_output.is_null() {
                     continue;
@@ -159,6 +175,7 @@ impl OutPointsCache {
             .insert(*block.block_hash(), added_outpoints);
         self.removed_outpoints
             .insert(*block.block_hash(), removed_outpoints);
+        self.utxo_deltas.insert(*block.block_hash(), utxo_delta);
 
         Ok(())
     }
@@ -209,6 +226,7 @@ impl OutPointsCache {
         let block_hash = block.block_hash();
         self.added_outpoints.remove(block_hash);
         self.removed_outpoints.remove(block_hash);
+        self.utxo_deltas.remove(block_hash);
     }
 }
 
@@ -346,6 +364,10 @@ mod test {
                         address_1.clone() => vec![OutPoint::new(tx_0.txid(), 0)]
                     },
                 },
+                utxo_deltas: maplit::btreemap! {
+                    *block_0.block_hash() => 1,
+                    *block_1.block_hash() => 1, // coinbase(1 output) + spend(1 input, 1 output) = +1
+                },
             }
         );
 
@@ -382,6 +404,9 @@ mod test {
                         address_1 => vec![OutPoint::new(tx_0.txid(), 0)]
                     },
                 },
+                utxo_deltas: maplit::btreemap! {
+                    *block_1.block_hash() => 1,
+                },
             }
         );
 
@@ -392,7 +417,8 @@ mod test {
             OutPointsCache {
                 tx_outs: maplit::btreemap! {},
                 added_outpoints: maplit::btreemap! {},
-                removed_outpoints: maplit::btreemap! {}
+                removed_outpoints: maplit::btreemap! {},
+                utxo_deltas: maplit::btreemap! {},
             }
         );
     }
@@ -502,6 +528,9 @@ mod test {
                 },
                 removed_outpoints: maplit::btreemap! {
                     *block_0.block_hash() => maplit::btreemap! {}
+                },
+                utxo_deltas: maplit::btreemap! {
+                    *block_0.block_hash() => 1,
                 },
             }
         );

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -447,25 +447,6 @@ impl UtxoSet {
     }
 }
 
-/// Counts the net UTXOs created by the given blocks, added to a base count.
-///
-/// Each output creates a UTXO; each input (except coinbase) spends a UTXO.
-pub fn count_utxos_in_blocks<'a>(
-    base_count: u64,
-    blocks: impl IntoIterator<Item = &'a Block>,
-) -> u64 {
-    let mut total = base_count as i64;
-    for block in blocks {
-        for tx in block.txdata() {
-            total += tx.output().len() as i64;
-            if !tx.is_coinbase() {
-                total -= tx.input().len() as i64;
-            }
-        }
-    }
-    total.max(0) as u64
-}
-
 fn init_address_utxos(
 ) -> StableBTreeMap<Blob<{ AddressUtxo::BOUND.max_size() as usize }>, (), Memory> {
     StableBTreeMap::init(crate::memory::get_address_utxos_memory())
@@ -594,8 +575,8 @@ mod test {
     use super::*;
     use crate::{
         address_utxoset::AddressUtxoSet,
-        genesis_block, runtime,
-        test_utils::{build_chain, BlockBuilder, TestBlocksCache, TransactionBuilder},
+        runtime,
+        test_utils::{BlockBuilder, TestBlocksCache, TransactionBuilder},
         types::into_dogecoin_network,
         unstable_blocks::UnstableBlocks,
     };
@@ -1287,85 +1268,5 @@ mod test {
             .map(|tx| tx.output().len())
             .sum::<usize>();
         num_inputs + num_outputs
-    }
-
-    #[test]
-    fn count_utxos_in_blocks_empty() {
-        assert_eq!(count_utxos_in_blocks(0, vec![]), 0);
-        assert_eq!(count_utxos_in_blocks(5, vec![]), 5);
-    }
-
-    #[test]
-    fn count_utxos_in_blocks_genesis_only() {
-        let genesis = genesis_block(Network::Regtest);
-        let blocks: Vec<&Block> = vec![&genesis];
-        assert_eq!(count_utxos_in_blocks(0, blocks), 1);
-    }
-
-    #[test]
-    fn count_utxos_in_blocks_chain_of_coinbase_blocks() {
-        let network = Network::Regtest;
-        let blocks = build_chain(network, 3, 1, false);
-        let blocks_refs: Vec<&Block> = blocks.iter().collect();
-        // Genesis + 2 blocks, each with 1 coinbase output. Total = 3 UTXOs.
-        assert_eq!(count_utxos_in_blocks(0, blocks_refs), 3);
-    }
-
-    #[test]
-    fn count_utxos_in_blocks_with_spending_transactions() {
-        let network = Network::Regtest;
-        let address: Address = random_p2pkh_address(into_dogecoin_network(network)).into();
-        let mut blocks: Vec<Block> = vec![];
-
-        // Block 1 (genesis): coinbase with 1 output → +1. Running total: 1.
-        let coinbase_tx = TransactionBuilder::coinbase()
-            .with_output(&address, 1000)
-            .build();
-        blocks.push(
-            BlockBuilder::genesis()
-                .with_transaction(coinbase_tx.clone())
-                .build(),
-        );
-        assert_eq!(count_utxos_in_blocks(0, &blocks), 1);
-
-        // Block 2: coinbase (1 output) + spend_tx (1 input, 3 outputs).
-        // Net: +1 + (3 - 1) = +3. Running total: 4.
-        let coinbase_tx_2 = TransactionBuilder::coinbase()
-            .with_output(&address, 1000)
-            .build();
-        let spend_tx = TransactionBuilder::new()
-            .with_input(OutPoint::new(coinbase_tx.txid(), 0))
-            .with_output(&address, 300)
-            .with_output(&address, 300)
-            .with_output(&address, 400)
-            .build();
-        blocks.push(
-            BlockBuilder::with_prev_header(blocks.last().unwrap().header())
-                .with_transaction(coinbase_tx_2)
-                .with_transaction(spend_tx.clone())
-                .build(),
-        );
-        assert_eq!(count_utxos_in_blocks(0, &blocks), 4);
-        assert_eq!(count_utxos_in_blocks(1, &blocks[1..]), 4);
-
-        // Block 3: coinbase (1 output) + spend_tx_2 (2 inputs, 1 output).
-        // Net: +1 + (1 - 2) = 0. Running total: 4.
-        let coinbase_tx_3 = TransactionBuilder::coinbase()
-            .with_output(&address, 1000)
-            .build();
-        let spend_tx_2 = TransactionBuilder::new()
-            .with_input(OutPoint::new(spend_tx.txid(), 0))
-            .with_input(OutPoint::new(spend_tx.txid(), 1))
-            .with_output(&address, 600)
-            .build();
-        blocks.push(
-            BlockBuilder::with_prev_header(blocks.last().unwrap().header())
-                .with_transaction(coinbase_tx_3)
-                .with_transaction(spend_tx_2)
-                .build(),
-        );
-        assert_eq!(count_utxos_in_blocks(0, &blocks), 4);
-        assert_eq!(count_utxos_in_blocks(1, &blocks[1..]), 4);
-        assert_eq!(count_utxos_in_blocks(4, &blocks[2..]), 4);
     }
 }


### PR DESCRIPTION
Cherry-pick the following commits from [dfinity/bitcoin-canister](https://github.com/dfinity/bitcoin-canister):

- https://github.com/dfinity/bitcoin-canister/commit/949c2aa: feat: add utxo_deltas cache for improved get_blockchain_info performance (#513)

## Commit 949c2aa (partial) description

Add `utxo_delta` in the `OutPointsCache` (heap) to cache the net UTXO count change per block (outputs created - inputs spent). This is then used in the `get_blockchain_info` endpoint to retrieve the number of utxos in the blockchain. Previously, `get_blockchain_info` would read all transactions in unstable blocks to compute the number of utxos which is quite inefficient.

It was not possible to use the existing `added_outpoints` and `removed_outpoints` field from `OutPointsCache` as these do not contain outpoints where the output does not conform to a standard address (such as P2PK addresses).

Note that during the first upgrade, the `utxo_delta` field will be empty and the result of `get_blockchain_info` will be inaccurate. This inaccuracy is a one-time issue on the first upgrade only, and self-heals as the ~1440 unstable blocks are ingested. This is deemed acceptable for a non-critical info endpoint.