### PR TITLE
chore(upstream): DEFI-2834: cherry-pick from dfinity/bitcoin-canister@master (707ef54)

### DIFF
--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -405,7 +405,7 @@ impl BlockTree {
         BlockChain::new_with_successors(first, chain_rev)
     }
 
-    /// Bottom-up DFS returning (accumulated_difficulty, depth, main_chain_reversed).
+    /// Bottom-up DFS returning (accumulated_difficulty, main_chain_length, main_chain_reversed).
     fn main_chain_by_difficulty_inner(&self) -> (DifficultyBasedDepth, usize, Vec<&CachedBlock>) {
         let self_difficulty = DifficultyBasedDepth::new(self.root.difficulty());
 
@@ -420,8 +420,8 @@ impl BlockTree {
         // Using strict `>` means the first child that sets `best_key` is kept
         // on ties, so the earliest-received branch wins.
         for child in self.children.iter() {
-            let (child_diff, child_depth, child_chain) = child.main_chain_by_difficulty_inner();
-            let key = (child_diff, child_depth);
+            let (child_diff, child_length, child_chain) = child.main_chain_by_difficulty_inner();
+            let key = (child_diff, child_length);
 
             if key > best_key {
                 best_key = key;
@@ -430,9 +430,9 @@ impl BlockTree {
         }
 
         let total_difficulty = self_difficulty + best_key.0;
-        let total_depth = 1 + best_key.1;
+        let total_length = 1 + best_key.1;
         best_chain.push(&self.root);
-        (total_difficulty, total_depth, best_chain)
+        (total_difficulty, total_length, best_chain)
     }
 
     /// Returns the length of the main chain determined by most accumulated
@@ -471,8 +471,8 @@ impl BlockTree {
         }
 
         let total_difficulty = self_difficulty + best_key.0;
-        let total_depth = 1 + best_key.1;
-        (total_difficulty, total_depth)
+        let total_length = 1 + best_key.1;
+        (total_difficulty, total_length)
     }
 
     /// Returns a `BlockTree` where the hash of the root block matches the provided `block_hash`

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -1211,7 +1211,7 @@ mod test {
         assert_eq!(get_main_chain_length(&forest), 3);
     }
 
-    // Contested deeper in the tree: the main chain stops at the inner fork.
+    // Tied fork deeper in the tree: first-received child wins at the inner fork.
     //
     // * (d=5) -> A (d=10) -> B (d=20)
     //                     -> C (d=20)
@@ -1405,7 +1405,7 @@ mod test {
         assert_eq!(get_main_chain_length(&forest), 2);
     }
 
-    // Three children: two tie, third loses. Still contested.
+    // Three children: two tie, third loses.
     //
     //     * (d=1)
     //   / | \


### PR DESCRIPTION
Cherry-pick the following commit from [dfinity/bitcoin-canister](https://github.com/dfinity/bitcoin-canister):

- https://github.com/dfinity/bitcoin-canister/commit/707ef54: chore: clarify main-chain tie-break terminology in comments and naming (#530)

Follow-up to Copilot review comments on #117. Doc/comment/naming only - no behavior change.