### PR TITLE
ci: only post canbench results on PRs, not on push to master

### DIFF
--- a/.github/workflows/canbench-post-comment.yml
+++ b/.github/workflows/canbench-post-comment.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   download-results:
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-benchmarks.outputs.matrix }}


### PR DESCRIPTION
## Summary
- Cherry-picks dfinity/bitcoin-canister#532 (commit `0165570`).
- The `Post Canbench results` workflow runs on `workflow_run` completion for both PRs and pushes to `master`. On pushes to `master` there is no PR to comment on, so the `post-comment` job fails (`No issue/pull request in input neither in current context.`).
- Skip the `download-results` job (which `post-comment` depends on) when the triggering event was not a `pull_request`.

Observed failure that motivated this: https://github.com/dfinity/dogecoin-canister/actions/runs/26573977550

🤖 Generated with [Claude Code](https://claude.com/claude-code)