### PR TITLE
perf: DEFI-2966: Avoid deep-cloning ingesting_block on every heartbeat

### DIFF
--- a/canister/src/api/fee_percentiles.rs
+++ b/canister/src/api/fee_percentiles.rs
@@ -322,7 +322,7 @@ mod test {
                 }
             }
 
-            state::ingest_stable_blocks_into_utxoset(state);
+            let _ = state::ingest_stable_blocks_into_utxoset(state);
         });
     }
 

--- a/canister/src/api/get_block_headers.rs
+++ b/canister/src/api/get_block_headers.rs
@@ -209,7 +209,7 @@ mod test {
         with_state_mut(|state| {
             insert_block(state, block1).unwrap();
             insert_block(state, block2).unwrap();
-            ingest_stable_blocks_into_utxoset(state);
+            let _ = ingest_stable_blocks_into_utxoset(state);
         });
     }
 
@@ -466,7 +466,7 @@ mod test {
             with_state_mut(|state| insert_block(state, block).unwrap());
         }
 
-        with_state_mut(ingest_stable_blocks_into_utxoset);
+        let _ = with_state_mut(ingest_stable_blocks_into_utxoset);
 
         blobs
     }
@@ -704,7 +704,7 @@ mod test {
             });
         }
         with_state_mut(|state| {
-            ingest_stable_blocks_into_utxoset(state);
+            let _ = ingest_stable_blocks_into_utxoset(state);
         });
 
         // Verify that headers after AuxPow height activation are larger than 80 bytes

--- a/canister/src/heartbeat.rs
+++ b/canister/src/heartbeat.rs
@@ -4,7 +4,7 @@ use crate::{
     state::{self, ResponseToProcess},
     types::{
         GetSuccessorsCompleteResponse, GetSuccessorsRequest, GetSuccessorsRequestInitial,
-        GetSuccessorsResponse,
+        GetSuccessorsResponse, Slicing,
     },
     with_state, with_state_mut,
 };
@@ -23,11 +23,20 @@ pub async fn heartbeat() {
     collect_metrics();
     maybe_burn_cycles();
 
-    if ingest_stable_blocks_into_utxoset() {
-        // Exit the heartbeat if stable blocks had been ingested.
-        // This is a precaution to not exceed the instructions limit.
-        print("Done ingesting stable blocks.");
-        return;
+    match ingest_stable_blocks_into_utxoset() {
+        // Ingestion paused mid-block (time-sliced): a full budget was already spent, so
+        // exit the heartbeat as a precaution to not exceed the instructions limit.
+        Slicing::Paused(()) => {
+            print("Paused while ingesting a stable block. Exiting heartbeat.");
+            return;
+        }
+        // A stable block finished ingesting this round: exit for the same precaution.
+        Slicing::Done(true) => {
+            print("Done ingesting stable blocks. Exiting heartbeat.");
+            return;
+        }
+        // Nothing was ingested; carry on to fetching/processing.
+        Slicing::Done(false) => {}
     }
 
     if maybe_fetch_blocks().await {
@@ -192,7 +201,7 @@ async fn maybe_fetch_blocks() -> bool {
     true
 }
 
-fn ingest_stable_blocks_into_utxoset() -> bool {
+fn ingest_stable_blocks_into_utxoset() -> Slicing<(), bool> {
     with_state_mut(state::ingest_stable_blocks_into_utxoset)
 }
 
@@ -437,7 +446,7 @@ mod test {
     }
 
     #[async_std::test]
-    async fn time_slices_large_blocks() {
+    async fn time_slices_large_blocks_without_fetching_while_ingesting() {
         let network = Network::Regtest;
         let doge_network = into_dogecoin_network(network);
 
@@ -482,6 +491,12 @@ mod test {
         // Assert that the blocks have been ingested.
         assert_eq!(with_state(state::main_chain_height), 2);
 
+        // Number of `get_successors` calls issued so far (only the single fetch above).
+        // While stable blocks are still being ingested, the heartbeat must return early
+        // and must NOT issue a new `get_successors` request.
+        let fetches_after_processing =
+            runtime::GET_SUCCESSORS_RESPONSES_INDEX.with(|i| *i.borrow());
+
         // Ingest stable blocks.
         runtime::performance_counter_reset();
         heartbeat().await;
@@ -493,6 +508,12 @@ mod test {
         assert_eq!(partial_block.next_tx_idx, 2);
         assert_eq!(partial_block.next_input_idx, 1);
         assert_eq!(partial_block.next_output_idx, 0);
+        // The paused ingestion returned early without fetching new blocks.
+        assert_eq!(
+            runtime::GET_SUCCESSORS_RESPONSES_INDEX.with(|i| *i.borrow()),
+            fetches_after_processing,
+            "heartbeat fetched new blocks while a stable block was still being ingested",
+        );
 
         // Ingest more stable blocks.
         runtime::performance_counter_reset();
@@ -504,6 +525,12 @@ mod test {
         assert_eq!(partial_block.next_tx_idx, 5);
         assert_eq!(partial_block.next_input_idx, 1);
         assert_eq!(partial_block.next_output_idx, 0);
+        // Still ingesting, still no new fetch.
+        assert_eq!(
+            runtime::GET_SUCCESSORS_RESPONSES_INDEX.with(|i| *i.borrow()),
+            fetches_after_processing,
+            "heartbeat fetched new blocks while a stable block was still being ingested",
+        );
 
         // Only the genesis block has been fully processed, so the stable height is one.
         assert_eq!(with_state(|s| s.utxos.next_height()), 1);
@@ -520,6 +547,19 @@ mod test {
 
         // The stable height is now updated to include `block_1`.
         assert_eq!(with_state(|s| s.utxos.next_height()), 2);
+
+        // No heartbeat fetched new blocks while ingestion was ongoing, including the
+        // one that completed it.
+        assert_eq!(
+            runtime::GET_SUCCESSORS_RESPONSES_INDEX.with(|i| *i.borrow()),
+            fetches_after_processing,
+            "heartbeat fetched new blocks while ingesting stable blocks",
+        );
+
+        // Restore the shared (thread-local) performance-counter mock to its default so this
+        // test does not affect others that may run later on the same thread.
+        runtime::set_performance_counter_step(0);
+        runtime::performance_counter_reset();
     }
 
     #[async_std::test]

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -411,7 +411,7 @@ mod test {
         for block in blocks[1..].iter() {
             with_state_mut(|s| {
                 crate::state::insert_block(s, block.clone()).unwrap();
-                crate::state::ingest_stable_blocks_into_utxoset(s);
+                let _ = crate::state::ingest_stable_blocks_into_utxoset(s);
             });
         }
 
@@ -798,7 +798,7 @@ mod test {
         for block in blocks[1..].iter() {
             with_state_mut(|s| {
                 crate::state::insert_block(s, block.clone()).unwrap();
-                crate::state::ingest_stable_blocks_into_utxoset(s);
+                let _ = crate::state::ingest_stable_blocks_into_utxoset(s);
             });
         }
 

--- a/canister/src/state.rs
+++ b/canister/src/state.rs
@@ -173,8 +173,15 @@ pub fn insert_block(state: &mut State, block: Block) -> Result<(), InsertBlockEr
 /// NOTE: This method does a form of time-slicing to stay within the instruction limit, and
 /// multiple calls may be required for all the stable blocks to be ingested.
 ///
-/// Returns a bool indicating whether or not the state has changed.
-pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
+/// Returns:
+///   * `Slicing::Paused(())` if ingestion was time-sliced and paused mid-block, so
+///     further calls are needed to finish the current block.
+///   * `Slicing::Done(true)` if all stable blocks were ingested during this call.
+///   * `Slicing::Done(false)` if there was nothing to ingest.
+///
+/// The `bool` carried by `Done` reports whether any ingestion work happened, which the
+/// heartbeat uses to decide whether it may move on to fetching new blocks this round.
+pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> Slicing<(), bool> {
     fn pop_block(state: &mut State, ingested_block_hash: BlockHash) {
         let stable_height = state.stable_height();
         // Pop the stable block.
@@ -184,22 +191,21 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
         assert_eq!(popped_block.unwrap().block_hash(), &ingested_block_hash);
     }
 
-    let prev_state = (
-        state.utxos.next_height(),
-        &state.utxos.ingesting_block.clone(),
-    );
-    let has_state_changed = |state: &State| -> bool {
-        prev_state != (state.utxos.next_height(), &state.utxos.ingesting_block)
-    };
+    // Tracks whether this call performed any stable-block ingestion work. Note that a
+    // `Slicing::Paused` slice returns early rather than setting this flag: a paused slice
+    // has already spent a full ingestion budget, so the heartbeat must not also
+    // fetch/process this round.
+    let mut did_work = false;
 
     // Finish ingesting the stable block that's partially ingested, if that exists.
     print("Running ingest_block_continue...");
     match state.utxos.ingest_block_continue() {
         None => {} // No block to continue ingesting.
-        Some(Slicing::Paused(())) => return has_state_changed(state),
+        Some(Slicing::Paused(())) => return Slicing::Paused(()),
         Some(Slicing::Done((ingested_block_hash, stats))) => {
             state.metrics.block_ingestion_stats = stats;
-            pop_block(state, ingested_block_hash)
+            pop_block(state, ingested_block_hash);
+            did_work = true;
         }
     }
 
@@ -217,15 +223,16 @@ pub fn ingest_stable_blocks_into_utxoset(state: &mut State) -> bool {
             .insert_block(&block, state.utxos.next_height());
 
         match state.utxos.ingest_block(block) {
-            Slicing::Paused(()) => return has_state_changed(state),
+            Slicing::Paused(()) => return Slicing::Paused(()),
             Slicing::Done((ingested_block_hash, stats)) => {
                 state.metrics.block_ingestion_stats = stats;
-                pop_block(state, ingested_block_hash)
+                pop_block(state, ingested_block_hash);
+                did_work = true;
             }
         }
     }
 
-    has_state_changed(state)
+    Slicing::Done(did_work)
 }
 
 pub fn insert_next_block_headers(state: &mut State, next_block_headers: &[BlockHeaderBlob]) {
@@ -518,7 +525,7 @@ mod test {
 
             for block in blocks[1..].iter() {
                 insert_block(&mut state, block.clone()).unwrap();
-                ingest_stable_blocks_into_utxoset(&mut state);
+                let _ = ingest_stable_blocks_into_utxoset(&mut state);
             }
 
             let mut bytes = vec![];
@@ -531,7 +538,7 @@ mod test {
     }
 
     #[test]
-    fn block_ingestion_stats_are_updated() {
+    fn ingest_stable_blocks_updates_stats_and_reports_work() {
         let stability_threshold = 0;
         let num_blocks = 3;
         let num_transactions_per_block = 10;
@@ -542,15 +549,30 @@ mod test {
         let mut state = State::new(cache, stability_threshold, network, blocks[0].clone());
 
         assert_eq!(state.stable_height(), 0);
+        // Nothing is stable yet (the genesis block has no successor) -> nothing to ingest.
+        assert_eq!(
+            ingest_stable_blocks_into_utxoset(&mut state),
+            Slicing::Done(false)
+        );
+
         insert_block(&mut state, blocks[1].clone()).unwrap();
 
-        // The genesis block is now stable. Ingest it.
+        // The genesis block is now stable. Ingesting it fully completes in one call.
         let metrics_before = state.metrics.block_ingestion_stats.clone();
-        ingest_stable_blocks_into_utxoset(&mut state);
+        assert_eq!(
+            ingest_stable_blocks_into_utxoset(&mut state),
+            Slicing::Done(true)
+        );
         assert_eq!(state.stable_height(), 1);
 
         // Verify that the stats have been updated.
         assert_ne!(metrics_before, state.metrics.block_ingestion_stats);
+
+        // Nothing new is stable now -> nothing to ingest.
+        assert_eq!(
+            ingest_stable_blocks_into_utxoset(&mut state),
+            Slicing::Done(false)
+        );
 
         // Ingest the next block. This time, the performance counter is set so that
         // the ingestion is time-sliced.
@@ -559,9 +581,14 @@ mod test {
         insert_block(&mut state, blocks[2].clone()).unwrap();
         let metrics_before = state.metrics.block_ingestion_stats.clone();
         let mut num_rounds = 0;
+        let mut saw_paused = false;
         while state.stable_height() == 1 {
             assert_eq!(metrics_before, state.metrics.block_ingestion_stats);
-            ingest_stable_blocks_into_utxoset(&mut state);
+            // Every slice either pauses mid-block or finishes the block on the final call.
+            match ingest_stable_blocks_into_utxoset(&mut state) {
+                Slicing::Paused(()) => saw_paused = true,
+                Slicing::Done(did_work) => assert!(did_work),
+            }
             crate::runtime::performance_counter_reset();
             num_rounds += 1;
         }
@@ -569,11 +596,23 @@ mod test {
         // Assert that the block has been ingested.
         assert_eq!(state.stable_height(), 2);
 
-        // Assert that the block ingestion has been time-sliced.
+        // Assert that the block ingestion has been time-sliced (paused at least once).
         assert!(num_rounds > 1);
+        assert!(saw_paused);
 
         // Assert the stats have been updated.
         assert_ne!(metrics_before, state.metrics.block_ingestion_stats);
+
+        // Everything stable has been ingested -> nothing to ingest.
+        assert_eq!(
+            ingest_stable_blocks_into_utxoset(&mut state),
+            Slicing::Done(false)
+        );
+
+        // Restore the shared (thread-local) performance-counter mock to its default so this
+        // test does not affect others that may run later on the same thread.
+        crate::runtime::set_performance_counter_step(0);
+        crate::runtime::performance_counter_reset();
     }
 
     #[test]

--- a/canister/src/utxo_set.rs
+++ b/canister/src/utxo_set.rs
@@ -458,7 +458,10 @@ fn init_balances() -> StableBTreeMap<Address, u128, Memory> {
 
 /// A state for maintaining a stable block that is partially ingested into the UTXO set.
 /// Used for time slicing.
-#[derive(Serialize, Deserialize, PartialEq, Clone, Debug, Eq)]
+#[derive(Serialize, Deserialize, PartialEq, Debug, Eq)]
+// `Clone` is only needed by tests; deriving it in production would invite the
+// kind of expensive deep clone this type is designed to avoid on the hot path.
+#[cfg_attr(test, derive(Clone))]
 pub struct IngestingBlock {
     pub block: Block,
     pub next_tx_idx: usize,

--- a/canister/src/validation.rs
+++ b/canister/src/validation.rs
@@ -181,7 +181,7 @@ mod test {
             // Insert all the blocks except the last block.
             for block in blocks[1..blocks.len() - 1].iter() {
                 insert_block(&mut state, block.clone()).unwrap();
-                ingest_stable_blocks_into_utxoset(&mut state);
+                let _ = ingest_stable_blocks_into_utxoset(&mut state);
             }
 
             // Try validating the last block header (which wasn't inserted above).


### PR DESCRIPTION
## Purpose

Cherry-pick of dfinity/bitcoin-canister#538.

`ingest_stable_blocks_into_utxoset` cloned and `PartialEq`-compared the entire `ingesting_block` on **every heartbeat**, purely to decide whether any ingestion work had happened. That structure is the full block (stored twice internally, no `Arc`) plus the monotonically growing `utxos_delta` — all heap data. Under the **deterministic memory tracker (DMT)** those reads are charged per accessed page, against the same instruction counter the ingestion loop uses to time-slice. The block half is constant across all slices of a block yet is re-cloned/compared every heartbeat.

This replaces the clone + deep-compare with a cheap boolean derived directly from the slicing results, removing that avoidable per-slice cost from the block-ingestion hot path.

## Notes

- Behaviour is unchanged: a paused slice always mutates `ingesting_block` (via the round counter), so the previous comparison already returned `true` in that case; returning early on a paused slice is also the safe choice for the self-imposed instruction-limit guard (the heartbeat then declines to also fetch/process in the same round).
- `Clone` on `IngestingBlock` is now derived only under `cfg(test)`, so production code cannot reintroduce the deep clone.
- Stacked on #129, which fixes a flaky `e2e-scenario-1` height wait. That wait races against an intermediate `stable_height`, and this change makes the canister pass through it faster.
- Followed by #126-#128, which add a steady-state heartbeat benchmark and act on what it shows.
