### PR TITLE
perf: DEFI-2966: Make BlockTree::get_hashes O(n) instead of O(n²)

### DIFF
--- a/benchmarks/legacy/canbench_results.yml
+++ b/benchmarks/legacy/canbench_results.yml
@@ -79,13 +79,13 @@ benches:
   heartbeat_steady_state_synced:
     total:
       calls: 1
-      instructions: 806902
+      instructions: 117647
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
       build_get_successors_request:
         calls: 1
-        instructions: 707743
+        instructions: 18356
         heap_increase: 0
         stable_memory_increase: 0
       collect_metrics_tip_depths:

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -517,10 +517,16 @@ impl BlockTree {
 
     /// Returns the hashes of all blocks in the tree.
     pub fn get_hashes(&self) -> Vec<BlockHash> {
-        let mut hashes = Vec::with_capacity(self.children.len() + 1);
-        hashes.push(*self.root.block_hash());
-        hashes.extend(self.children.iter().flat_map(|child| child.get_hashes()));
+        let mut hashes = Vec::new();
+        self.collect_hashes(&mut hashes);
         hashes
+    }
+
+    fn collect_hashes(&self, hashes: &mut Vec<BlockHash>) {
+        hashes.push(*self.root.block_hash());
+        for child in self.children.iter() {
+            child.collect_hashes(hashes);
+        }
     }
 
     /// Returns all blocks in the tree with their depths
@@ -879,6 +885,33 @@ mod test {
 
         assert_eq!(height_2_block_hash, fork[1].block_hash());
         assert_eq!(height_2_depth, 1);
+    }
+
+    // The heartbeat pops index 0 as the anchor (`processed_block_hashes.remove(0)`), so
+    // `get_hashes` must return every block once in pre-order with the root first.
+    #[test]
+    fn get_hashes_is_preorder_with_root_first() {
+        // root -> a -> b
+        //    \--> c
+        let root = BlockBuilder::genesis().build();
+        let a = BlockBuilder::with_prev_header(root.header()).build();
+        let b = BlockBuilder::with_prev_header(a.header()).build();
+        let c = BlockBuilder::with_prev_header(root.header()).build();
+
+        let mut tree = test_tree(root.clone());
+        tree.extend_cached(a.clone()).unwrap();
+        tree.extend_cached(b.clone()).unwrap();
+        tree.extend_cached(c.clone()).unwrap();
+
+        assert_eq!(
+            tree.get_hashes(),
+            vec![
+                *root.block_hash(),
+                *a.block_hash(),
+                *b.block_hash(),
+                *c.block_hash(),
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Purpose

Cherry-pick of dfinity/bitcoin-canister#541.

The `heartbeat_steady_state_synced` benchmark (added in the base PR #126) showed that building the `get_successors` request dominated the synchronous per-round heartbeat work (~88%). The cause is `BlockTree::get_hashes`: it recursed by returning a fresh `Vec` per node and concatenating it into the parent, re-copying each node's descendants' hashes at every level — O(n²) on a long chain. The heartbeat rebuilds this list every round, so DMT charges it repeatedly.

This rewrites `get_hashes` as a single depth-first traversal into one shared accumulator (O(n)), preserving the pre-order / root-first ordering the heartbeat relies on (it pops index 0 as the anchor), and adds a test locking that contract.

## Measured effect

Via `heartbeat_steady_state_synced`:

| scope | before | after | Δ |
|---|---|---|---|
| `build_get_successors_request` | 707.7K | 18.4K | **−97.4%** |
| total synchronous round | 806.9K | 117.6K | **−85.4%** |

(`collect_metrics`/`tip_depths`, now the largest remaining term at ~74K, is the follow-up.)

## Review notes

- Stacked on #126 (the benchmark), which is stacked on #125. Bases will be retargeted to `master` as the stack merges bottom-up.
- canbench measures instructions, not DMT page-access charges.