### PR TITLE
perf: DEFI-2966: Cache unstable-block tip depths, refresh at push/pop

### DIFF
--- a/benchmarks/legacy/canbench_results.yml
+++ b/benchmarks/legacy/canbench_results.yml
@@ -79,7 +79,7 @@ benches:
   heartbeat_steady_state_synced:
     total:
       calls: 1
-      instructions: 117647
+      instructions: 44884
       heap_increase: 0
       stable_memory_increase: 0
     scopes:
@@ -90,12 +90,12 @@ benches:
         stable_memory_increase: 0
       collect_metrics_tip_depths:
         calls: 1
-        instructions: 73672
+        instructions: 904
         heap_increase: 0
         stable_memory_increase: 0
       ingest_no_op:
         calls: 1
-        instructions: 22131
+        instructions: 22136
         heap_increase: 0
         stable_memory_increase: 0
   insert_300_blocks:

--- a/canister/src/blocktree.rs
+++ b/canister/src/blocktree.rs
@@ -261,14 +261,18 @@ impl BlockTree {
 
     /// Returns the depths of all tips in the tree.
     pub fn tip_depths(&self) -> Vec<usize> {
-        if self.children.is_empty() {
-            return vec![1]; // Leaf node, depth is 1
+        let mut depths = Vec::new();
+        let mut stack = vec![(self, 1usize)];
+        while let Some((node, depth)) = stack.pop() {
+            if node.children.is_empty() {
+                depths.push(depth);
+            } else {
+                for child in node.children.iter() {
+                    stack.push((child, depth + 1));
+                }
+            }
         }
-
-        self.children
-            .iter()
-            .flat_map(|child| child.tip_depths().into_iter().map(|d| d + 1))
-            .collect()
+        depths
     }
 
     fn get_child_blocks(&self) -> Vec<&CachedBlock> {

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -257,6 +257,9 @@ pub fn post_upgrade(config_update: Option<SetConfigRequest>) {
     // even if the upgrade event interrupted the canister fetching state.
     with_state_mut(|state| {
         reset_syncing_state(state);
+
+        // Repopulate the tip-depths cache, which defaults to empty for older state.
+        state.unstable_blocks.refresh_tip_depths_cache();
     });
 
     // Update the state based on the provided configuration.

--- a/canister/src/unstable_blocks.rs
+++ b/canister/src/unstable_blocks.rs
@@ -72,6 +72,9 @@ pub struct UnstableBlocks {
     network: Network,
     // The headers of the blocks that are expected to be received.
     next_block_headers: NextBlockHeaders,
+    // Cached depths of all tips in `tree`, refreshed on push/pop.
+    #[serde(default)]
+    tip_depths_cache: Vec<usize>,
 }
 
 impl UnstableBlocks {
@@ -88,12 +91,16 @@ impl UnstableBlocks {
             .insert(utxos, &anchor, utxos.next_height())
             .expect("anchor block must be valid.");
 
+        let tree = BlockTree::new_with_cache(blocks_cache, anchor);
+        let tip_depths_cache = tree.tip_depths();
+
         Self {
             stability_threshold,
-            tree: BlockTree::new_with_cache(blocks_cache, anchor),
+            tree,
             outpoints_cache,
             network,
             next_block_headers: NextBlockHeaders::default(),
+            tip_depths_cache,
         }
     }
 
@@ -147,7 +154,12 @@ impl UnstableBlocks {
 
     /// Returns the depths of all tips in the tree.
     pub fn tip_depths(&self) -> Vec<usize> {
-        self.tree.tip_depths()
+        self.tip_depths_cache.clone()
+    }
+
+    /// Recomputes the cached tip depths from the current tree.
+    pub fn refresh_tip_depths_cache(&mut self) {
+        self.tip_depths_cache = self.tree.tip_depths();
     }
 
     fn get_network(&self) -> Network {
@@ -278,6 +290,8 @@ pub fn pop(blocks: &mut UnstableBlocks, stable_height: Height) -> Option<Block> 
 
     blocks.next_block_headers.remove_until_height(stable_height);
 
+    blocks.refresh_tip_depths_cache();
+
     // The block returned here is the previous anchor block. The new
     // anchor block was its child (see above).
     Some(tree.into_root_and_remove_from_cache())
@@ -305,6 +319,8 @@ pub fn push(
     parent_block_tree.extend_cached(block)?;
 
     blocks.next_block_headers.remove(&block_hash);
+
+    blocks.refresh_tip_depths_cache();
 
     Ok(())
 }
@@ -484,6 +500,42 @@ mod test {
         // children yet, so calling `pop` should return `None`.
         assert_eq!(peek(&forest), None);
         assert_eq!(pop(&mut forest, 0), None);
+    }
+
+    #[test]
+    fn tip_depths_cache_stays_consistent_through_push_and_pop() {
+        let block_0 = BlockBuilder::genesis().build();
+        let block_1 = BlockBuilder::with_prev_header(block_0.header()).build();
+        let block_2 = BlockBuilder::with_prev_header(block_1.header()).build();
+        let block_3 = BlockBuilder::with_prev_header(block_2.header()).build();
+        let fork = BlockBuilder::with_prev_header(block_0.header()).build();
+
+        let network = Network::Regtest;
+        let utxos = UtxoSet::new(network);
+        let cache = TestBlocksCache::new(network);
+        let mut forest = UnstableBlocks::new(cache, &utxos, 2, block_0.clone(), network);
+
+        let sorted_tip_depths = |forest: &UnstableBlocks| {
+            let mut depths = forest.tip_depths();
+            depths.sort_unstable();
+            depths
+        };
+
+        assert_eq!(sorted_tip_depths(&forest), vec![1]);
+
+        // `fork` branches off the anchor, so the tree then has tips at depths 4 and 2.
+        for (block, expected) in [
+            (block_1, vec![2]),
+            (block_2, vec![3]),
+            (block_3, vec![4]),
+            (fork, vec![2, 4]),
+        ] {
+            push(&mut forest, &utxos, block).unwrap();
+            assert_eq!(sorted_tip_depths(&forest), expected);
+        }
+
+        assert!(pop(&mut forest, 0).is_some());
+        assert_eq!(sorted_tip_depths(&forest), vec![3]);
     }
 
     #[test]


### PR DESCRIPTION
## Purpose

Cherry-pick of dfinity/bitcoin-canister#543.

`collect_metrics` runs on every heartbeat and walked the entire unstable block tree via `tip_depths`, purely to populate a diagnostic histogram. The unstable tree only changes when a block is pushed or popped, so that per-round O(n) walk re-derives the same values under DMT charging.

This caches the tip depths in `UnstableBlocks` and refreshes them only at push/pop. `tip_depths` now returns the cached value, so the per-round `collect_metrics` no longer walks the tree, while the every-round histogram cadence and values are preserved. The cache is serialized (`serde(default)` for backward-compatibility) and rebuilt from the tree in `post_upgrade` for state written by an older version.

`BlockTree::tip_depths` is also made iterative: it is now called on every push, and an unstable tree on regtest can be many hundreds of blocks deep, so a recursive walk would risk overflowing the stack (the per-heartbeat call already carried this latent risk).

## Measured effect

Via `heartbeat_steady_state_synced`:

| scope | before | after | Δ |
|---|---|---|---|
| `collect_metrics_tip_depths` | 73.7K | 0.9K | **−98.8%** |
| total synchronous round | 117.6K | 44.9K | **−61.9%** |

Combined with the `get_hashes` fix (base PR), the synchronous per-round heartbeat work is down from ~807K to ~45K instructions.

## Review notes

- New test `tip_depths_cache_stays_consistent_through_push_and_pop` locks the cache-vs-fresh-walk invariant; the serde round-trip and post-upgrade tests pass with the new field.
- Stacked on #127, itself stacked on #126 and #125. Bases will be retargeted to `master` as the stack merges bottom-up.
- canbench measures instructions, not DMT page-access charges.