### PR TITLE
test: Wait for e2e chain heights with >= instead of an exact match

### DIFF
--- a/e2e-tests/scenario-1.sh
+++ b/e2e-tests/scenario-1.sh
@@ -33,8 +33,9 @@ if ! [[ $BLOCKCHAIN_INFO == *"height = 5"* ]]; then
   exit 1
 fi
 
-# Wait until the ingestion of stable blocks is complete.
-wait_until_stable_height 3 60
+# Wait until the ingestion of stable blocks is complete. With a main chain of height 5
+# and a stability threshold of 2, blocks 0..3 become stable, so ingestion rests at 4.
+wait_until_stable_height 4 60
 
 # Fetch the balance of an address we do not expect to have funds.
 BALANCE=$(dfx canister call dogecoin dogecoin_get_balance '(record {

--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -9,20 +9,28 @@ use_prebuilt_dogecoin_wasm() {
   fi
 }
 
-# Waits until the main chain of the dogecoin canister has reached a certain height.
-wait_until_main_chain_height () {
-  HEIGHT=$1
-  ATTEMPTS=$2
+# Polls the canister's metrics until the gauge `METRIC` has reached at least `HEIGHT`,
+# giving up after `ATTEMPTS` polls.
+#
+# NOTE: the comparison is `>=`, not `==`. The canister only passes *through* the
+# intermediate heights on its way to the terminal one, and a once-per-second poll can
+# easily miss a height that is only held for a fraction of a second.
+wait_until_metric_at_least () {
+  METRIC=$1
+  HEIGHT=$2
+  ATTEMPTS=$3
 
   DOGECOIN_CANISTER_ID=$(dfx canister id dogecoin)
 
   while
     METRICS=$(curl "http://$DOGECOIN_CANISTER_ID.raw.localhost:8000/metrics")
-    ! [[ "$METRICS" == *"main_chain_height $HEIGHT"* ]]; do
+    # Metrics lines are `<name> <value> <timestamp>`; take the value of an exact name match.
+    VALUE=$(echo "$METRICS" | awk -v name="$METRIC" '$1 == name { print $2; exit }')
+    ! [[ "$VALUE" =~ ^[0-9]+$ ]] || (( VALUE < HEIGHT )); do
       ((ATTEMPTS-=1))
 
       if [[ $ATTEMPTS -eq 0 ]]; then
-	echo "TIMED OUT"
+	echo "TIMED OUT waiting for $METRIC >= $HEIGHT (last value: ${VALUE:-none})"
 	exit 1
       fi
 
@@ -30,25 +38,14 @@ wait_until_main_chain_height () {
   done
 }
 
+# Waits until the main chain of the dogecoin canister has reached a certain height.
+wait_until_main_chain_height () {
+  wait_until_metric_at_least "main_chain_height" "$1" "$2"
+}
+
 # Waits until the stable chain of the Dogecoin canister has reached a certain height.
 wait_until_stable_height () {
-  HEIGHT=$1
-  ATTEMPTS=$2
-
-  DOGECOIN_CANISTER_ID=$(dfx canister id dogecoin)
-
-  while
-    METRICS=$(curl "http://$DOGECOIN_CANISTER_ID.raw.localhost:8000/metrics")
-    ! [[ "$METRICS" == *"stable_height $HEIGHT"* ]]; do
-      ((ATTEMPTS-=1))
-
-      if [[ $ATTEMPTS -eq 0 ]]; then
-	echo "TIMED OUT"
-	exit 1
-      fi
-
-      sleep 1
-  done
+  wait_until_metric_at_least "stable_height" "$1" "$2"
 }
 
 # Returns the number of UTXOs found in a response.

--- a/e2e-tests/utils.sh
+++ b/e2e-tests/utils.sh
@@ -27,11 +27,13 @@ wait_until_metric_at_least () {
     # Metrics lines are `<name> <value> <timestamp>`; take the value of an exact name match.
     VALUE=$(echo "$METRICS" | awk -v name="$METRIC" '$1 == name { print $2; exit }')
     ! [[ "$VALUE" =~ ^[0-9]+$ ]] || (( VALUE < HEIGHT )); do
-      ((ATTEMPTS-=1))
+      # Assignment, not `((ATTEMPTS-=1))`: the latter returns 1 when the result is 0,
+      # which under the callers' `set -e` would abort before the message below is printed.
+      ATTEMPTS=$((ATTEMPTS - 1))
 
       if [[ $ATTEMPTS -eq 0 ]]; then
-	echo "TIMED OUT waiting for $METRIC >= $HEIGHT (last value: ${VALUE:-none})"
-	exit 1
+        echo "TIMED OUT waiting for $METRIC >= $HEIGHT (last value: ${VALUE:-none})"
+        exit 1
       fi
 
       sleep 1


### PR DESCRIPTION
## Purpose

`e2e-scenario-1` fails intermittently at `wait_until_stable_height 3`, and the failure is in the test, not the canister.

`wait_until_main_chain_height` and `wait_until_stable_height` poll the metrics endpoint once a second and match the height as an exact substring. That only works if the canister comes to rest on the awaited height. Any height it merely passes through can be missed, and the helper then spins until it times out.

`scenario-1` waits for `stable_height 3`, which is exactly such an intermediate value: with a main chain of height 5 and a stability threshold of 2, ingestion settles at 4. On a green run the window at 3 is one or two polls wide, and the `get_blockchain_info` call sitting between the two waits is enough to consume it. When that happens the scenario burns all 60 attempts against a canister that is already at its correct terminal state.

That target is an accident. `222c458` (upstream `bitcoin-canister#48`) renamed `wait_until_height` to `wait_until_stable_height` and switched the matched metric from `main_chain_height` to `stable_height`, while in the same commit raising the stability threshold to 2 and appending two blocks. The literal `3` was carried over untouched — it used to mean "all blocks received", which was terminal. It has been one short of the resting height ever since, and the comment above it ("Wait until the ingestion of stable blocks is complete") has described the intent rather than the code.

Evidence from the failing run: the metrics poll shows `main_chain_height 5 / stable_height 3` for a single poll, then `stable_height 4` for the remaining 60 — the value the canister correctly stays at.

This compares numerically with `>=` instead, which is what every call site actually means ("wait until at least this much progress"), and reports the last observed value on timeout so a real hang is still diagnosable. `scenario-1` now waits for 4, the height ingestion actually rests at, so the barrier means what its comment says.

The timeout message also had to be made reachable: `((ATTEMPTS-=1))` returns exit status 1 when the result is 0, so under the callers' `set -Eexuo pipefail` the script aborted on the decrement itself. Neither the old `TIMED OUT` nor the new message was ever printed. It is a plain assignment now.

## Notes

- Both helpers now share one polling implementation; call sites are otherwise unchanged.
- The other call sites (`scenario-2`, `charge-cycles-on-reject`, `disable-api-if-not-fully-synced-flag`) all wait for terminal heights, so `>=` does not change their behaviour — it just removes the same latent trap.
- Surfaced while cherry-picking the heartbeat perf work (#125–#128): the cheaper the per-round heartbeat gets, the faster ingestion passes through the intermediate heights and the narrower this window becomes.
